### PR TITLE
Specify the transform when bundling into play-apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "gulp-vulcanize": "^6.1.0",
     "vinyl-source-stream": "^1.1.0",
     "watchify": "^3.7.0"
+  },
+  "browserify": {
+    "transform": [["babelify", { "presets": ["es2015"] }]]
   }
 }


### PR DESCRIPTION
This declares a transform in case we want to bundle this module with browserify.

https://github.com/babel/babelify#why-arent-files-in-node_modules-being-transformed
