### PR TITLE
Removing the base tag to fix blockly's bin

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,9 +72,7 @@ gulp.task('js', ['babel', 'bundle', 'dom-util'], () => {
     gulp.src('./.tmp/app/index.html')
         .pipe(utils.vulcanize({ inlineScripts: true }))
         .pipe($.crisper({ scriptInHead: false }))
-        .pipe($.htmlReplace({ base: `
-            <base href="/" target="_blank">
-            `,
+        .pipe($.htmlReplace({
             config: `
             <script type="text/javascript">
                 window.config = ${JSON.stringify(utils.getConfig())};


### PR DESCRIPTION
The base tag buggers up the URL to clip paths in Blockly, resulting in the bin sprite not being cropped properly.

Related to: https://github.com/KanoComputing/online/issues/119

<img width="637" alt="screen shot 2016-04-08 at 12 03 33" src="https://cloud.githubusercontent.com/assets/169328/14381945/f8ced9ca-fd81-11e5-81df-654f59537a1f.png">

<img width="637" alt="screen shot 2016-04-08 at 12 03 33" src="http://i.giphy.com/3o8doOlGO3pjQa5h28.gif">
