### PR TITLE
Implementing support for z-index

### DIFF
--- a/app/elements/kano-workspace-controls/kano-workspace-controls.html
+++ b/app/elements/kano-workspace-controls/kano-workspace-controls.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../behaviors.html">
+<link rel="import" href="../../bower_components/Sortable/Sortable.html">
 <dom-module id="kano-workspace-controls">
     <style>
     :host {
@@ -51,10 +52,13 @@
         transform: rotate(45deg);
     }
     :host .parts {
-        padding: 10px;
+        padding: 0px 10px;
         overflow-y: auto;
         @apply(--layout-horizontal);
         @apply(--layout-wrap);
+
+        align-items: center;
+        flex: 1;
     }
     :host .part {
         padding: 3px;
@@ -93,7 +97,7 @@
                 </div>
 
             </div>
-            <div class="parts" id="parts-tray">
+            <sortable-js class="parts" id="parts-tray">
                 <template is="dom-repeat"
                             items="{{parts}}"
                             as="part">

--- a/app/elements/kano-workspace/kano-workspace.html
+++ b/app/elements/kano-workspace/kano-workspace.html
@@ -28,6 +28,14 @@
     :host ::content #dropzone {
         width: 100%;
         height: 100%;
+
+        position: relative;
+    }
+
+    :host ::content div#dropzone > * {
+        position: absolute;
+        top: 0px;
+        left: 0px
     }
     </style>
     <template>

--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "paper-dialog": "PolymerElements/paper-dialog#^1.0.4",
     "google-map": "GoogleWebComponents/google-map#^1.1.10",
     "paper-styles": "PolymerElements/paper-styles#^1.1.4",
-    "marked-element": "PolymerElements/marked-element#^1.1.3"
+    "marked-element": "PolymerElements/marked-element#^1.1.3",
+    "Sortable": "^1.4.2"
   }
 }


### PR DESCRIPTION
This adds support for z-index based on the order of devices in the tray. I used the Sortable.js component that @paulvarache suggested (for @rcocetta it's got 12k and doesn't import jQuery).

Since moving the objects in the tray rearranges their order in the canvas, I changed the positioning in the dropzone to absolute which means that all widgets have the same transform origin and changing their order doesn't break their positioning.

The z-index is also determined by the order of items within the tag, so rearranging them produces the behaviour we want without having to force it manually using CSS.

Related to: https://github.com/KanoComputing/online/issues/107
