### PR TITLE
Removing make-apps min/max buttons only in Dashboard mode

### DIFF
--- a/rpi/bin/make-apps
+++ b/rpi/bin/make-apps
@@ -127,7 +127,15 @@ if len(sys.argv) > 1:
 # TODO: Temporarily we will use the online version
 # URL = "http://localhost:{}".format(make_apps.server.DEFAULT_PORT)
 URL = "http://make-apps-kit.kano.me"
-UI_PROC = subprocess.Popen(['kano-web-view', '--title', 'Make Apps', '--decorate', URL])
+cmdline=['kano-web-view', '--title', 'Make Apps', '--decorate' ]
+
+# If we are launched from within the Dashboard, tell kano-web-view
+# to remove the Minimize/Maximize buttons, because we do not have a taskbar.
+if os.getenv('KANO_BLOCKS_SCREEN_HEIGHT'):
+    cmdline.append('--no-minmax')
+
+cmdline.append(URL)
+UI_PROC = subprocess.Popen(cmdline)
 
 
 # This process is really a factory/watchdog process. It launches the UI and


### PR DESCRIPTION
This change depends on this PR:
- https://github.com/KanoComputing/kano-web-view/pull/3

cc @convolu @tombettany 
