### PR TITLE
Don't apply positioning twice

### DIFF
--- a/app/scripts/service/components.js
+++ b/app/scripts/service/components.js
@@ -154,7 +154,11 @@ class ComponentStore {
 
         component = `
             <dom-module id="${id}">
-                <style></style>
+                <style>
+                    :host kano-ui-viewport * {
+                        position: absolute;
+                    }
+                </style>
                 <template>
                     <kano-ui-viewport mode="scaled"
                                 view-width="${workspaceRect.width}"
@@ -169,8 +173,7 @@ class ComponentStore {
                     properties: {
                         parts: {
                             type: Object,
-                            value: JSON.parse("${partsString}"),
-                            observer: 'partsChanged'
+                            value: JSON.parse("${partsString}")
                         }
                     },
                     attached: function () {
@@ -180,15 +183,6 @@ class ComponentStore {
                             }.bind(this)
                         };
                         ${wrappedCode}
-                    },
-                    partsChanged () {
-                        var el;
-                        Object.keys(this.parts).forEach(function (id) {
-                            el = this.$$('#' + id);
-                            el.style.position = 'absolute';
-                            el.style.left = this.parts[id].position.x + 'px';
-                            el.style.top = this.parts[id].position.y + 'px';
-                        }.bind(this));
                     }
                 });
             </${scr}>


### PR DESCRIPTION
The positioning in the generated component was applied twice (via top/left and translate). This removes the absolute positioning and keeps the transitions.

Correctly positioned share example: http://play-apps.herokuapp.com/#!/app/570bd2306ebab40f00c68981

Related to: https://github.com/KanoComputing/online/issues/142
