### PR TITLE
Styles need to be included from components directly

### DIFF
--- a/app/elements/ui/kano-ui-button/kano-ui-button.html
+++ b/app/elements/ui/kano-ui-button/kano-ui-button.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../behaviors.html">
-<link rel="import" href="../kano-ui-style/kano-ui-style.html">
 
 <dom-module id="kano-ui-button">
-    <style include="kano-ui-style"></style>
     <style>
     :host {
         display: inline-block;

--- a/app/elements/ui/kano-ui-frame/kano-ui-frame.html
+++ b/app/elements/ui/kano-ui-frame/kano-ui-frame.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../behaviors.html">
-<link rel="import" href="../kano-ui-style/kano-ui-style.html">
 
 <dom-module id="kano-ui-frame">
-    <style include="kano-ui-style"></style>
     <style>
     :host {
         display: inline-block;

--- a/app/elements/ui/kano-ui-label/kano-ui-label.html
+++ b/app/elements/ui/kano-ui-label/kano-ui-label.html
@@ -1,7 +1,4 @@
-<link rel="import" href="../kano-ui-style/kano-ui-style.html">
-
 <dom-module id='kano-ui-label'>
-    <style include="kano-ui-style"></style>
     <style>
         :host {
             display: inline-block;

--- a/app/elements/ui/kano-ui-map/kano-ui-map.html
+++ b/app/elements/ui/kano-ui-map/kano-ui-map.html
@@ -1,9 +1,7 @@
 <link rel="import" href="../../../bower_components/google-map/google-map.html">
 <link rel="import" href="../behaviors.html">
-<link rel="import" href="../kano-ui-style/kano-ui-style.html">
 
 <dom-module id="kano-ui-map">
-    <style include="kano-ui-style"></style>
     <style>
     :host {
         display: inline-block;

--- a/app/elements/ui/kano-ui-text-input/kano-ui-text-input.html
+++ b/app/elements/ui/kano-ui-text-input/kano-ui-text-input.html
@@ -1,7 +1,4 @@
-<link rel="import" href="../kano-ui-style/kano-ui-style.html">
-
 <dom-module id="kano-ui-text-input">
-    <style include="kano-ui-style"></style>
     <style>
     :host {
         display: inline-block;

--- a/app/elements/ui/kano-ui-video/kano-ui-video.html
+++ b/app/elements/ui/kano-ui-video/kano-ui-video.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../behaviors.html">
-<link rel="import" href="../kano-ui-style/kano-ui-style.html">
 
 <dom-module id="kano-ui-video">
-    <style include="kano-ui-style"></style>
     <style>
     :host {
         display: inline-block;


### PR DESCRIPTION
In play apps, we don't import the kano-ui file anywhere, so importing the style there didn't work.

This adds the import into each of the component. I didn't break the file down yet because it's still really small and it could get more confusing than we need.

Are the imports like this ok, @paulvarache?
