### PR TITLE
Fix blockly toolbox pain (KanoComputing/online#223)

### DIFF
--- a/app/elements/kano-blockly/blockly-override.js
+++ b/app/elements/kano-blockly/blockly-override.js
@@ -78,6 +78,58 @@ Blockly.Flyout.prototype.position = function () {
 };
 
 /**
+ * Initializes the toolbox.
+ */
+Blockly.Toolbox.prototype.init = function() {
+  var workspace = this.workspace_,
+    svg = workspace.getParentSvg(),
+    container = svg.parentNode;
+
+  // Create an HTML container for the Toolbox menu.
+  this.HtmlDiv = goog.dom.createDom('div', 'blocklyToolboxDiv');
+  this.HtmlDiv.setAttribute('dir', workspace.RTL ? 'RTL' : 'LTR');
+  container.appendChild(this.HtmlDiv);
+
+  // Clicking on toolbar closes popups.
+  Blockly.bindEvent_(this.HtmlDiv, 'mousedown', this,
+      function(e) {
+        if (Blockly.isRightButton(e) || e.target == this.HtmlDiv) {
+          // Close flyout.
+          Blockly.hideChaff(false);
+        } else {
+          // Just close popups.
+          Blockly.hideChaff(true);
+        }
+      });
+  var workspaceOptions = {
+    disabledPatternId: workspace.options.disabledPatternId,
+    parentWorkspace: workspace,
+    RTL: workspace.RTL
+  };
+  /**
+   * @type {!Blockly.Flyout}
+   * @private
+   */
+  this.flyout_ = new Blockly.Flyout(workspaceOptions);
+  goog.dom.insertSiblingAfter(this.flyout_.createDom(), workspace.svgGroup_);
+  this.flyout_.init(workspace);
+
+  this.CONFIG_['cleardotPath'] = workspace.options.pathToMedia + '1x1.gif';
+  this.CONFIG_['cssCollapsedFolderIcon'] =
+      'blocklyTreeIconClosed' + (workspace.RTL ? 'Rtl' : 'Ltr');
+  var tree = new Blockly.Toolbox.TreeControl(this, this.CONFIG_);
+  this.tree_ = tree;
+  tree.setShowRootNode(false);
+  tree.setShowLines(false);
+  tree.setShowExpandIcons(false);
+  tree.setSelectedItem(null);
+  this.populate_(workspace.options.languageTree);
+  tree.render(this.HtmlDiv);
+  this.addColour_();
+  this.position();
+};
+
+/**
  * Move the toolbox to the edge.
  */
 Blockly.Toolbox.prototype.position = function() {
@@ -96,8 +148,7 @@ Blockly.Toolbox.prototype.position = function() {
         treeDiv.style.left = svgPosition.x + 'px';
     }
     treeDiv.style.height = svgSize.height + 'px';
-    treeDiv.style.width = svgSize.width / 6 + 'px';
-    treeDiv.style.top = svgPosition.y + 'px';
+    treeDiv.style.top = '0px';
     this.width = treeDiv.offsetWidth;
     if (!this.workspace_.RTL) {
         // For some reason the LTR toolbox now reports as 1px too wide.

--- a/app/elements/kano-blockly/kano-blockly.html
+++ b/app/elements/kano-blockly/kano-blockly.html
@@ -83,27 +83,6 @@
             this.toolboxDiv = this.toolboxElements[2];
             return this.toolboxElements;
         }
-        /**
-         * Set the sisibility of all the toolbox elements to hidden
-         * Needs to be done since these elements are added to the DOM
-         * by Blockly
-         */
-        hide () {
-            this.getToolboxElements().forEach((el) => {
-                el.style.visibility = 'hidden';
-            });
-            this.resize();
-        }
-        /**
-         * Set the sisibility of all the toolbox elements to visible
-         * Counteract the effects of `hideToolbox`
-         */
-        show () {
-            this.getToolboxElements().forEach((el) => {
-                el.style.visibility = 'visible';
-            });
-            this.resize();
-        }
         detached () {
             this.workspace.dispose();
         }

--- a/app/elements/kano-root-view/kano-root-view.html
+++ b/app/elements/kano-root-view/kano-root-view.html
@@ -260,8 +260,7 @@
                 'computeTitle(selectedPage)'
             ];
             this.listeners = {
-                'pages.iron-select': 'pageEntered',
-                'pages.iron-deselect': 'pageLeft'
+                'pages.iron-select': 'pageEntered'
             };
         }
         computeDropdownClass (eventSelectOpen) {
@@ -383,19 +382,8 @@
             // Trigger a resize on blockly when we get back to the
             // code editor page
             if (e.detail.item.getAttribute('name') === 'code') {
-                this.showCodeEditor();
+                this.$['code-editor'].resize();
             }
-        }
-        pageLeft (e) {
-            if (e.detail.item.getAttribute('name') === 'code') {
-                this.hideCodeEditor();
-            }
-        }
-        hideCodeEditor () {
-            this.$['code-editor'].hide();
-        }
-        showCodeEditor () {
-            this.$['code-editor'].show();
         }
         hasEvents (selected) {
             return selected &&

--- a/app/style/blockly.sass
+++ b/app/style/blockly.sass
@@ -31,7 +31,7 @@ div.blocklyTreeRoot
 div.blocklyTreeRow
     height: auto !important
     line-height: 20px !important
-    padding: 10px 0px
+    padding: 10px 12px !important
     margin: 0px
     color: white
     text-align: center

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -117,6 +117,7 @@ gulp.task('views', () => {
         return gulp.src('app/views/**/*.html')
             .pipe(utils.vulcanize({
                 inlineScripts: true,
+                inlineCss: true,
                 stripExcludes: common
             }))
             .pipe($.crisper({ scriptInHead: false }))
@@ -127,7 +128,7 @@ gulp.task('views', () => {
 
 gulp.task('scenes', () => {
     gulp.src('app/assets/stories/**/*.html')
-        .pipe(utils.vulcanize({ inlineScripts: true }))
+        .pipe(utils.vulcanize({ inlineScripts: true, inlineCss: true }))
         .pipe($.crisper({ scriptInHead: false }))
         .pipe($.if('*.js', $.babel({ presets: ['es2015'] })))
         .pipe(gulp.dest('www/assets/stories'));


### PR DESCRIPTION
Related to KanoComputing/online#223

I just override the init function of the blocky toolbox to add it inside the container instead of the body. Then I just had to update the `position` function to fix the top of the toolbox to the top of the workspace.
This enabled me to remove all the hack to hide/show the toolbox
