### PR TITLE
Fixed urls of links on homepage

### DIFF
--- a/app/elements/kano-app-list/kano-app-list.html
+++ b/app/elements/kano-app-list/kano-app-list.html
@@ -76,7 +76,7 @@
         </template>
         <template is="dom-repeat" items="{{apps}}" as="app">
             <div class="block">
-                <a class="app-list-item" href="//apps.kano.me/#!/app/{{app.id}}">
+                <a class="app-list-item" href="//app.kano.me/#!/app/{{app.id}}">
                     <iron-image src="{{app.cover_url}}" sizing="cover" class="app-list-item-image"></iron-image>
                     <div class="info">
                         <div class="app-name">{{app.title}}</div>


### PR DESCRIPTION
Links to apps on the home page were pointing to apps.kano.me instead of app.kano.me

<!---
@huboard:{"custom_state":"archived"}
-->
