### PR TITLE
Npm run build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ bower install
 If it is the first time you use the project, run
 
 ```shell
-gulp build
+npm run build
 ```
 
 It will prepare everything.
 
-Once done, you can start the development gulp task
+Once done, you can start the development task
 
 ```shell
-gulp dev
+npm run dev
 ```
 
 This will watch the files and rebuild when necessary. It also start a web server listening on port 4000

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prepare": "npm install && bower install",
     "start": "node_modules/.bin/gulp serve-prod",
     "build": "gulp build",
+    "dev": "gulp dev",
     "content-snap": "bash kano-content-package.sh"
   },
   "engines": {


### PR DESCRIPTION
Since gulp is already installed as a dependency, there's no need to require it to be installed globally - It's enough to wrap in in npm scripts - Here's the changes:
- Add `npm run build` task as opposed to using `gulp build`
- Add `npm run dev` task as opposed to using `gulp dev`
- Update readme
- Got rid of default `npm test` task

<!---
@huboard:{"custom_state":"archived"}
-->
