### PR TITLE
Color fixes

### DIFF
--- a/app/elements/inputs/kano-input-color/kano-input-color.html
+++ b/app/elements/inputs/kano-input-color/kano-input-color.html
@@ -51,21 +51,22 @@
 
         attached () {
             this.colors = [
-                '#70c222', //green
-                '#F8EB1E', //yellow
-                '#e95c5a', // red
-                '#ff842a', // kanorange
-                '#59b3d0', // blue
-                'black', // black
-                '#683D12', //brown
-                '#642682', //violet
-                '#2A3080', //purple
-                '#DB7D92', //pink
-                '#E61974',//Dark pink
-                '#3CAA36',//Light green
-                '#0E6633',//dark green
-                '#f5f5f5',//white
-                '#7d7a73'//black
+                '#F5F5F5',  // White
+                '#CCCCCC',  // Light Gray
+                '#7D7A73',  // Gray
+                '#000000',  // Black
+                '#E95C5A',  // Red
+                '#FF842A',  // Kano Orange
+                '#F8EB1E',  // Yellow
+                '#70C222',  // Light Green
+                '#3CAA36',  // Green
+                '#0E6633',  // Dark Green
+                '#59b3d0',  // Light Blue
+                '#2A3080',  // Dark Blue
+                '#642682',  // Violet
+                '#E61974',  // Fuschia
+                '#DB7D92',  // Pink
+                '#683D12'   // Brown
             ];
             this.value = this.value || this.colors[0];
         }


### PR DESCRIPTION
This PR rearranges the colors in the color picker based on the color wheel, and moves white to the front of the list so that the background color is now white by default (fixing [#311](https://github.com/KanoComputing/online/issues/311))

Before: <img width="747" alt="screen shot 2016-05-05 at 8 00 42 am" src="https://cloud.githubusercontent.com/assets/340383/15037956/98e9547e-1297-11e6-9bf4-632c3eaca01d.png">

After: 
<img width="742" alt="screen shot 2016-05-05 at 8 00 59 am" src="https://cloud.githubusercontent.com/assets/340383/15037959/a029e2c6-1297-11e6-9a06-c0bda34802b8.png">

<!---
@huboard:{"custom_state":"archived"}
-->
