### PR TITLE
Ellipsize part labels to fit under the icon

### DIFF
--- a/app/elements/kano-ui-item/kano-ui-item.html
+++ b/app/elements/kano-ui-item/kano-ui-item.html
@@ -41,6 +41,10 @@
         font-size: 1em;
         text-align: center;
         color: #4A4A4A;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 62px;
+        white-space: nowrap;
     }
     </style>
     <template>


### PR DESCRIPTION
Related to: https://github.com/KanoComputing/online/issues/339

<img width="571" alt="screen shot 2016-05-11 at 16 33 52" src="https://cloud.githubusercontent.com/assets/169328/15186763/3cfe96ac-1796-11e6-84af-d5679d0ead2c.png">

<!---
@huboard:{"custom_state":"archived"}
-->
