### PR TITLE
Change location of the remix modal which made nonsense

### DIFF
--- a/app/assets/stories/common/kano-scene-editor/kano-scene-editor.html
+++ b/app/assets/stories/common/kano-scene-editor/kano-scene-editor.html
@@ -10,6 +10,41 @@
     :host kano-app-editor {
         @apply(--layout-flex);
     }
+    :host kano-challenge-progress {
+        position: absolute;
+        top: 20px;
+        right: 20px;
+    }
+    :host #challenge-completed .buttons {
+        @apply(--layout-horizontal);
+        @apply(--layout-around-justified);
+    }
+    :host #challenge-completed .buttons button {
+        @apply(--kano-button);
+        min-height: 45px;
+        font-weight: bold;
+    }
+
+    :host #challenge-completed .buttons .remix {
+        background: var(--color-orange);
+    }
+
+    :host #challenge-completed .buttons .share {
+        background: var(--color-kw-blue);
+    }
+
+    :host #challenge-completed .buttons .next-challenge {
+        background: var(--color-green);
+    }
+
+    :host #challenge-completed h2 {
+        color: var(--color-green);
+    }
+    :host .completed-message,
+    :host .completed-options {
+        @apply(--layout-vertical);
+        @apply(--layout-center-justified);
+    }
   </style>
   <template>
       <kano-app-challenge id="challenge"
@@ -25,9 +60,28 @@
                             class="editor"
                             ws-size="[[size]]"
                             running="{{running}}">
-              <kano-challenge-progress id="challenge-progress" progress="[[progress]]" title="[[storyName]]" next-challenge="[[nextStory]]" on-share-app="shareApp" remix-mode="[[scene.remix]]"></kano-challenge-progress>
+              <kano-challenge-progress id="challenge-progress" progress="[[progress]]" title="[[storyName]]" next-challenge="[[nextStory]]" on-share-app="shareApp" remix-mode="[[remix]]" on-next-story="goToNextStory"></kano-challenge-progress>
           </kano-app-editor>
       </kano-app-challenge>
+      <paper-dialog id="challenge-completed" with-backdrop on-iron-overlay-closed="goToRemixChallenge">
+          <div class="dialog pure-g">
+              <div class="pure-u-1 pure-u-md-1-3 completed-message">
+                  <div class="p-box">
+                      <h2>High five!</h2>
+                      <p> You have completed the [[storyName]] challenge </p>
+                  </div>
+              </div>
+              <div class="pure-u-1 pure-u-md-2-3 completed-options">
+                  <div class="buttons">
+                      <button class="share" on-tap="shareApp">Share</button>
+                      <button class="remix" on-tap="goToRemixChallenge">Remix</button>
+                      <template is="dom-if" if="[[nextStory]]">
+                          <button type="button" class="next-challenge" on-tap="goToNextStory">Next Challenge</button>
+                      </template>
+                  </div>
+              </div>
+          </div>
+      </paper-dialog>
   </template>
 </dom-module>
 <script type="text/javascript">
@@ -63,18 +117,22 @@
                 }
             };
             this.observers = [
-                'shareChanged(scene.share)'
+                'endedChanged(scene.ended)'
             ];
         }
 
-        shareChanged () {
-            if (this.scene.share) {
-                this.shareApp();
+        endedChanged () {
+            if (this.scene.ended) {
+                this.$['challenge-completed'].open();
             }
         }
 
         computeProgress (currentStep, scene) {
             return currentStep / scene.steps.length;
+        }
+
+        ready () {
+            this.remix = false;
         }
 
         attached () {
@@ -130,6 +188,16 @@
             this.$.editor.load(savedState.app, this.computeParts());
             challenge.set('stepIds', savedState.stepIds);
             challenge.set('blockIds', savedState.blockIds);
+        }
+        goToRemixChallenge () {
+            this.$['challenge-completed'].close();
+            this.remix = true;
+        }
+        goToNextStory () {
+            if (!this.nextStory) {
+                return;
+            }
+            window.location = `/story/${this.nextStory}`;
         }
     }
     Polymer(KanoSceneEditor);

--- a/app/elements/kano-challenge-progress/demo.html
+++ b/app/elements/kano-challenge-progress/demo.html
@@ -5,15 +5,62 @@
         <script src="../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
         <link rel="import" href="./kano-challenge-progress.html">
         <style is="custom-style">
-
+            :root {
+                --color-orange: #ff842a;
+                --color-dark-orange: #df6d24;
+                --color-darker-orange: #b1561c;
+            }
+            body {
+                display: flex;
+                font-family: Arial;
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            body>* {
+                margin: 12px;
+            }
+            * {
+                box-sizing: border-box;
+            }
+            .inputs {
+                display: flex;
+                flex-direction: column;
+            }
+            .events {
+                display: flex;
+                flex-direction: column;
+            }
         </style>
     </head>
     <body>
-        <template is="dom-bind">
-            <input type="range" name="name" value="{{val::input}}" min="0" max="1" step="0.1">
-            <input type="checkbox" name="name" checked="{{remix::change}}">
-            <span>[[remix]]</span>
-            <kano-challenge-progress progress="[[val]]" title="Demo Progress" remix-mode="[[remix]]"></kano-challenge-progress>
+        <template is="dom-bind" id="bind">
+            <div class="inputs">
+                <label for="">Challenge progress:</label>
+                <input type="range" name="name" value="{{val::input}}" min="0" max="1" step="0.1">
+                <label for="">Next story:</label>
+                <input type="text" name="name" value="{{next::input}}">
+                <label for="">Remix mode:<input type="checkbox" name="name" checked="{{remix::change}}"></label>
+            </div>
+            <kano-challenge-progress progress="[[val]]" title="Demo Progress" remix-mode="[[remix]]" next-challenge="[[next]]"></kano-challenge-progress>
+            <div class="events">
+                <h2>Events</h2>
+                <template is="dom-repeat" items="[[events]]">
+                    <div>[[item]]</div>
+                </template>
+            </div>
         </template>
+        <script type="text/javascript">
+            var bind = document.getElementById('bind');
+            bind.events = [];
+            bind.val = 0.1;
+            document.addEventListener('share-app', () => {
+                console.log('share-app');
+                bind.push('events', 'share-app');
+            });
+            document.addEventListener('next-story', () => {
+                bind.push('events', 'next-story');
+            });
+        </script>
     </body>
 </html>

--- a/app/elements/kano-challenge-progress/kano-challenge-progress.html
+++ b/app/elements/kano-challenge-progress/kano-challenge-progress.html
@@ -25,9 +25,8 @@ In this example we also assume that the next challenge URL is `/story/weather`
 <dom-module id="kano-challenge-progress">
     <style>
         :host {
-          position: absolute;
-          top: 20px;
-          right: 20px;
+            display: inline-block;
+            @apply(--layout-vertical-reverse);
         }
 
         :host .circular-progress {
@@ -37,6 +36,7 @@ In this example we also assume that the next challenge URL is `/story/weather`
             background: var(--color-orange, orange);
             padding: 8px;
             border-radius: 50%;
+            box-sizing: border-box;
         }
 
         :host .title {
@@ -46,7 +46,6 @@ In this example we also assume that the next challenge URL is `/story/weather`
             line-height: 40px;
             font-size: 15px;
             padding: 0 30px;
-            margin-top: 5px;
             margin-left: -15px;
             border-radius: 5px;
             min-width: 150px;
@@ -60,19 +59,17 @@ In this example we also assume that the next challenge URL is `/story/weather`
         }
 
         :host .progress {
-            display: flex;
-            flex-direction: row-reverse;
+            @apply(--layout-horizontal-reverse);
+            @apply(--layout-center);
         }
 
         :host .actions {
             background: var(--color-dark-orange, orange);
-            display: flex;;
-            width: 85%;
-            margin-right: 0;
+            @apply(--layout-vertical);
             margin-top: -28px;
             border-radius: 5px;
-            flex-direction: column;
-            margin-left: auto;
+            margin-left: 25px;
+            width: calc(100% - 25px);
         }
 
         :host .actions .empty-space {
@@ -104,6 +101,16 @@ In this example we also assume that the next challenge URL is `/story/weather`
         }
     </style>
     <template>
+        <template is="dom-if" if="{{remixMode}}">
+            <div class="actions">
+                <div class="empty-space"></div>
+                <template is="dom-if" if="{{nextChallenge}}">
+                    <a on-tap="goToNextStory"> Next Challenge </a>
+                    <div class="separator"></div>
+                </template>
+                <a on-tap="shareApp"> Share App </a>
+            </div>
+        </template>
         <div class="progress">
             <div class="title">
                 <p>{{title}}</p>
@@ -112,16 +119,6 @@ In this example we also assume that the next challenge URL is `/story/weather`
                 <kano-circle-progress value="[[progress]]"></kano-circle-progress>
             </div>
         </div>
-        <template is="dom-if" if="{{remixMode}}">
-            <div class="actions">
-                <div class="empty-space"></div>
-                <template is="dom-if" if="{{nextChallenge}}">
-                    <a on-tap="goToNextChallenge"> Next Challenge </a>
-                    <div class="separator"></div>
-                </template>
-                <a on-tap="shareApp"> Share App </a>
-            </div>
-        </template>
     </template>
 </dom-module>
 
@@ -158,7 +155,7 @@ In this example we also assume that the next challenge URL is `/story/weather`
             this.fire('share-app');
         }
 
-        goToNextChallenge () {
+        goToNextStory () {
             this.fire('next-story');
         }
 

--- a/app/elements/kano-story-scene/kano-story-scene.html
+++ b/app/elements/kano-story-scene/kano-story-scene.html
@@ -20,36 +20,6 @@
         right: 0px;
         display: none;
     }
-    :host #challenge-completed {
-        border-radius: 5px;
-    }
-
-    :host #challenge-completed .buttons button,
-    :host #challenge-completed .buttons a {
-        @apply(--kano-button);
-        border-radius: 5px;
-        margin: 0 10px;
-        min-height: 45px;
-        font-weight: bold;
-        text-transform: uppercase;
-        text-decoration: none;
-    }
-
-    :host #challenge-completed .buttons .remix {
-        background: var(--color-orange);
-    }
-
-    :host #challenge-completed .buttons .share {
-        background: var(--color-kw-blue);
-    }
-
-    :host #challenge-completed .buttons .next-challenge {
-        background: var(--color-green);
-    }
-
-    :host #challenge-completed h2 {
-        color: var(--color-green);
-    }
     </style>
     <template>
         <kano-view id="view"
@@ -57,30 +27,8 @@
                 view-name="[[name]]"
                 attributes="{{attributes}}"
                 on-scene-done="sceneFinished"
-                on-next-story="goToNextStory"
                 ></kano-view>
         <div id="overlay"></div>
-        <paper-dialog id="challenge-completed" with-backdrop on-iron-overlay-closed="goToRemixChallenge">
-            <div class="dialog pure-g">
-                <div class="pure-u-1 pure-u-md-1-3 vertical-aligned">
-                    <div class="p-box">
-                        <h2>High five!</h2>
-                        <p> You have completed the [[storyName]] challenge </p>
-                    </div>
-                </div>
-                <div class="pure-u-1 pure-u-md-2-3 vertical-aligned">
-                    <div class="p-box">
-                        <div class="buttons">
-                            <button class="share" on-tap="shareApp">Share</button>
-                            <button class="remix" on-tap="goToRemixChallenge">Remix</button>
-                            <template is="dom-if" if="[[nextStory]]">
-                                <button type="button" class="next-challenge" on-tap="goToNextStory">Next Challenge</button>
-                            </template>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </paper-dialog>
     </template>
 </dom-module>
 <script type="text/javascript">
@@ -127,25 +75,12 @@
             this.overlayDone = this.overlayDone.bind(this);
             this.overlay = null;
         }
-        shareApp () {
-            this.set('attributes.scene.share', true);
-        }
-        goToRemixChallenge () {
-            this.$['challenge-completed'].close();
-            this.set('attributes.scene.remix', true);
-        }
-        goToNextStory () {
-            if (!this.nextStory) {
-                return;
-            }
-            window.location = `/story/${this.nextStory}`;
-        }
         sceneFinished (e) {
             if (this.scene.overlay_after) {
                 e.stopPropagation();
                 this.setupOverlay(this.scene.overlay_after);
             } else if (this.scene.show_remix_options) {
-                this.$['challenge-completed'].open();
+                this.set('attributes.scene.ended', true);
             }
         }
         componentChanged () {
@@ -187,7 +122,7 @@
                 started = true;
             } else if (this.scene.overlay_after) {
                 if (this.scene.show_remix_options) {
-                    this.$['challenge-completed'].open();
+                    this.set('attributes.scene.ended', true);
                 } else {
                     this.fire('scene-done');
                 }


### PR DESCRIPTION
The end of challenge modal was in the `kano-story-scene` component. From there a lot of editor specific actions needed to be done. `kano-story-scene` is supposed to be completely agnostic of all theses actions like sharing, remixing...
Also, updated the `kano-challenge-progress`'s demo

<!---
@huboard:{"custom_state":"archived"}
-->
