### PR TITLE
Fix remix loading

### DIFF
--- a/app/elements/kano-app-list/kano-app-list.html
+++ b/app/elements/kano-app-list/kano-app-list.html
@@ -68,16 +68,16 @@
     <template>
     <div class="app-list">
         <template is="dom-if" if="{{isMyApps}}">
-        <div class="block">
-            <a class="app-list-item new-app" href="/make">
-                + New App
-            </a>
-        </div>
+            <div class="block">
+                <a class="app-list-item new-app" href="/make">
+                    + New App
+                </a>
+            </div>
         </template>
         <template is="dom-repeat" items="{{apps}}" as="app">
             <div class="block">
-                <a class="app-list-item" href='{{playUrl}}/app/{{app.id}}'>
-                    <iron-image src="{{app.cover_url}}" sizing="cover" class="app-list-item-image"></iron-image>
+                <a class="app-list-item" href="{{playUrl}}/app/{{app.id}}">
+                    <iron-image src="{{app.cover_url}}" sizing="cover" class="app-list-item-image" preload fade></iron-image>
                     <div class="info">
                         <div class="app-name">{{app.title}}</div>
                     </div>

--- a/app/elements/kano-root-view/kano-root-view.html
+++ b/app/elements/kano-root-view/kano-root-view.html
@@ -49,7 +49,8 @@
                 }
             };
             this.observers = [
-                'computeToolbox(parts.*)',
+                'computeToolbox(parts)',
+                'computeToolboxDebounced(parts.*)',
                 'computeToolbox(defaultCategories.*)',
                 'defaultCategoriesLoaded(defaultCategories.events)'
             ];
@@ -137,70 +138,71 @@
                 });
         }
         computeToolbox () {
-            this.debounce('computeToolbox', () => {
-                let categories,
-                    toolbox,
-                    parts = this.parts,
-                    blocks,
-                    weight;
-                if (!parts || !this.defaultCategories) {
-                    return;
-                }
-                this.computeBlocks();
-                // Reset events blocks
-                weight = {
-                    'ui': 1,
-                    'data': 2,
-                    'hardware': 3
-                };
-                categories = parts
-                    .map((ui) => {
-                        blocks = ui.blocks.map((definition) => {
-                            let block = definition.block(ui);
-                            block.colour = ui.colour;
-                            block.id = `${ui.id}#${block.id}`;
-                            return {
-                                id: block.id,
-                                colour: block.colour,
-                                shadow: block.shadow
-                            };
-                        });
+            let categories,
+                toolbox,
+                parts = this.parts,
+                blocks,
+                weight;
+            if (!parts || !this.defaultCategories) {
+                return;
+            }
+            this.computeBlocks();
+            // Reset events blocks
+            weight = {
+                'ui': 1,
+                'data': 2,
+                'hardware': 3
+            };
+            categories = parts
+                .map((ui) => {
+                    blocks = ui.blocks.map((definition) => {
+                        let block = definition.block(ui);
+                        block.colour = ui.colour;
+                        block.id = `${ui.id}#${block.id}`;
                         return {
-                            name: ui.name,
-                            colour: ui.colour,
-                            id: ui.type,
-                            weight: weight[ui.partType],
-                            blocks
+                            id: block.id,
+                            colour: block.colour,
+                            shadow: block.shadow
                         };
-                    })
-                    .sort((a, b) => {
-                        return a.weight - b.weight;
                     });
-
-                categories = categories || [];
-                categories = categories.filter((category) => category.blocks.length);
-
-                Object.keys(this.defaultCategories).forEach((id) => {
-                    let cat = this.defaultCategories[id];
-                    cat.blocks.forEach((block) => {
-                        block.colour = cat.colour;
-                    });
+                    return {
+                        name: ui.name,
+                        colour: ui.colour,
+                        id: ui.type,
+                        weight: weight[ui.partType],
+                        blocks
+                    };
+                })
+                .sort((a, b) => {
+                    return a.weight - b.weight;
                 });
 
-                toolbox = Object.keys(this.defaultCategories).filter(id => id !== 'background').map(id => this.defaultCategories[id]);
+            categories = categories || [];
+            categories = categories.filter((category) => category.blocks.length);
 
-                toolbox = toolbox
-                    .concat({ type: 'separator' });
-                if (this.defaultCategories.background) {
-                    toolbox.push(this.defaultCategories.background);
-                }
-                toolbox = toolbox.concat(categories);
-                this.set('toolbox', toolbox);
-                if (!this.toolboxReady) {
-                    this.$['code-editor'].resize();
-                }
-                this.toolboxReady = true;
-            }, 200);
+            Object.keys(this.defaultCategories).forEach((id) => {
+                let cat = this.defaultCategories[id];
+                cat.blocks.forEach((block) => {
+                    block.colour = cat.colour;
+                });
+            });
+
+            toolbox = Object.keys(this.defaultCategories).filter(id => id !== 'background').map(id => this.defaultCategories[id]);
+
+            toolbox = toolbox
+                .concat({ type: 'separator' });
+            if (this.defaultCategories.background) {
+                toolbox.push(this.defaultCategories.background);
+            }
+            toolbox = toolbox.concat(categories);
+            this.set('toolbox', toolbox);
+            if (!this.toolboxReady) {
+                this.$['code-editor'].resize();
+            }
+            this.toolboxReady = true;
+        }
+        computeToolboxDebounced () {
+            this.debounce('computeToolbox', () => this.computeToolbox(), 200);
         }
 
         getBlocklyWorkspace () {


### PR DESCRIPTION
Immediatly re-compute the toolbar when the parts change. Debounce this when a property of the parts change. When loading from localStorage or a remix, the `parts` property change, triggering an immediate re-compute of the toolbox, before the code is loaded.

<!---
@huboard:{"custom_state":"archived"}
-->
