### PR TITLE
Export parts array as an object and not a parseable string, prevent t…

### DIFF
--- a/app/scripts/service/components.js
+++ b/app/scripts/service/components.js
@@ -106,7 +106,7 @@ class ComponentStore {
             template.push(`<${tagName} id="${part.id}" model="{{parts.${part.id}}}" auto-start></${tagName}>`);
             return acc;
         }, {});
-        partsString = JSON.stringify(components).replace(/"/g, '\\"');
+        partsString = JSON.stringify(components);
 
         template = template.join('\n');
         // TODO find a better way to avoid having this script tag swallowed by
@@ -145,7 +145,7 @@ class ComponentStore {
                     properties: {
                         parts: {
                             type: Object,
-                            value: JSON.parse("${partsString}")
+                            value: ${partsString}
                         }
                     },
                     attached: function () {


### PR DESCRIPTION
…he escape quotes problems

Fixes not working shares like this one: https://app.kano.me/app/575708844f72e178541066da

<!---
@huboard:{"custom_state":"archived"}
-->
