### PR TITLE
Adding host and port parameters for the hardware URL

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -12,6 +12,7 @@ import Part from './part';
 import KanoWorldSdk from 'kano-world-sdk';
 import DragAndDrop from './drag-and-drop';
 import ProgressService from './service/progress';
+import HardwareAPI from './service/hardware-api';
 import config from './config';
 
 window.Kano = window.Kano || {};
@@ -33,6 +34,7 @@ window.Kano = window.Kano || {};
 
     MakeApps.sdk = KanoWorldSdk(config);
     MakeApps.progress = ProgressService(MakeApps.sdk);
+    MakeApps.HardwareAPI = HardwareAPI;
     MakeApps.sdk.registerForms();
 
     MakeApps.Modules = modules;

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -14,7 +14,7 @@ let COMMON = {
         "VOICE_API_URL": "http://api.voicerss.org",
         "VOICE_API_KEY": "65b85d9c94094d62bddfd37acd5786b4",
         "WEATHER_API_KEY": "79f483fba81614f1e7d1fea5a28b9750",
-        "HARDWARE_API_URL": "http://10.0.30.99:3000"
+        "HARDWARE_API_URL": "http://localhost:3000"
     },
     ENV = {
         "production": {

--- a/app/views/kano-view-editor/kano-view-editor.html
+++ b/app/views/kano-view-editor/kano-view-editor.html
@@ -129,20 +129,23 @@
             }
         },
         _getMode (context) {
-            var qs = '?' + context.querystring,
-                paramName = 'mode',
+            var modeFromQs = this._parseQsParam('mode');
+            return modeFromQs ? modeFromQs : 'normal';
+        },
+        _parseQsParam (name) {
+            var qs = '?' + this.context.querystring,
                 regex,
                 res;
 
             if (qs.length > 1) {
-                regex = new RegExp("[?&]" + paramName + "(=([^&#]*)|&|#|$)"),
+                regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
                 res = regex.exec(qs);
                 if (res && res[2]) {
                     return decodeURIComponent(res[2].replace(/\+/g, " "))
                 }
             }
 
-            return 'normal';
+            return null;
         },
         ready () {
             let workspaceSizeKey;
@@ -153,6 +156,15 @@
             this.modal = this.$['share-modal'];
 
             this.mode = Kano.MakeApps.Mode[this._getMode(this.context)];
+            if (this.mode.id === 'lightboard' || this.mode.id === 'camera')  {
+                let host = this._parseQsParam('host') || 'localhost',
+                    port = this._parseQsParam('port') || '3000',
+                    url = 'http://' + host + ':' + port;
+
+                Kano.MakeApps.HardwareAPI.config({
+                    HARDWARE_API_URL: url
+                });
+            }
 
             workspaceSizeKey = this.mode.sizeKey || 'WORKSPACE_FULL_SIZE';
 


### PR DESCRIPTION
Makes the HW url configurable via query string:

```
http://apps.kano.me/make?mode=lightboard&host=10.0.0.1&port=3000
```

<!---
@huboard:{"custom_state":"archived"}
-->
