### PR TITLE
Centre error messages in the page

### DIFF
--- a/app/elements/kano-app-player/kano-app-player.html
+++ b/app/elements/kano-app-player/kano-app-player.html
@@ -1,7 +1,8 @@
 <dom-module id="kano-app-player">
     <style>
         :host {
-          display: block;
+          display: flex;
+          align-items: center;
           @apply(--layout-horizontal);
         }
         :host ::content kano-user-component {


### PR DESCRIPTION
This pushes the error message into the middle of the page:

<img width="796" alt="screen shot 2016-06-09 at 15 57 42" src="https://cloud.githubusercontent.com/assets/169328/15934373/385eb8a8-2e5b-11e6-98cc-4e3be3e4ab1e.png">

<!---
@huboard:{"custom_state":"archived"}
-->
