### PR TITLE
Set API key on map ready

### DIFF
--- a/app/elements/ui/kano-ui-map/kano-ui-map.html
+++ b/app/elements/ui/kano-ui-map/kano-ui-map.html
@@ -38,13 +38,10 @@
                 value: () => {
                     return [];
                 }
-            },
-            apiKey: {
-                type: String,
-                value: Kano.MakeApps.config.GOOGLE_API_KEY
             }
         },
         ready () {
+            this.apiKey = Kano.MakeApps.config.GOOGLE_API_KEY;
             this.mapOptions = {
                 draggable: false,
                 scrollWheel: false


### PR DESCRIPTION
Setting the API key on the property value, don't leave enough time for the external apps to set the configuration object

<!---
@huboard:{"custom_state":"archived"}
-->
