### PR TITLE
Update output of clock

### DIFF
--- a/app/scripts/parts/clock.js
+++ b/app/scripts/parts/clock.js
@@ -14,7 +14,7 @@ export default clock = {
             return {
                 id: 'get_time',
                 message0: 'Clock: current %1',
-                output: true,
+                output: 'Number',
                 args0: [{
                     type: "field_dropdown",
                     name: "FIELD",


### PR DESCRIPTION
Related to https://trello.com/c/rV5riOo9/33-clock-output-should-be-recognised-as-a-number
