### PR TITLE
Trigger appmodules start and stop with the attached/detached lifecycl…

### DIFF
--- a/app/elements/kano-app-player/kano-app-player.html
+++ b/app/elements/kano-app-player/kano-app-player.html
@@ -46,6 +46,12 @@
                     value:false
                 }
             },
+            attached () {
+                Kano.AppModules.start();
+            },
+            detached () {
+                Kano.AppModules.stop();    
+            },
             _srcChanged () {
                 // Check that we are loading and html file. Bsing that on the extension is not the best solution
                 // as any server coulde return html content. This prevents loading of late setups bindings. For

--- a/app/views/kano-view-play/kano-view-play.html
+++ b/app/views/kano-view-play/kano-view-play.html
@@ -79,7 +79,6 @@
                 });
             this.worldUrl = Kano.MakeApps.config.WORLD_URL;
             Kano.AppModules.init(Kano.MakeApps.config);
-            Kano.AppModules.start();
         },
         _follow (e) {
             if (!this.user) {


### PR DESCRIPTION
…e callbacks

This will trigger a start and stop of the modules like `time` when the element `kano-app-player` is attached / detached. Since it is included in the external play bundle, will also update on MA
