### PR TITLE
Freeze polymer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "^1.2.4",
+    "polymer": "1.6.0",
     "page": "visionmedia/page.js#^1.6.4",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.2.3",
     "fetch": "^0.11.0",


### PR DESCRIPTION
The last Polymer release changed the way the urls are resolved. This causes a bug in iron-image when it tries to get an aria-label from the url. The bug has been spotted quite fast and a PR is already on its way (https://github.com/PolymerElements/iron-image/pull/87). Until then, I froze the version of Polymer to the previous one
