### PR TITLE
Fix sports challenge

### DIFF
--- a/app/assets/stories/sports_round/sports_round_data.json
+++ b/app/assets/stories/sports_round/sports_round_data.json
@@ -172,14 +172,18 @@
     },{
         "tooltips": [{
             "location": {
-                "category": "scrolling-text"
+                "category": {
+                    "part": "scrolling_text_1"
+                }
             },
             "position": "left",
             "text": "Open the scroll text tray"
         }],
         "validation": {
             "blockly": {
-                "open-flyout": "scrolling-text"
+                "open-flyout": {
+                    "part": "scrolling_text_1"
+                }
             }
         }
     },{


### PR DESCRIPTION
The sport challenge was using the generated id of the part. It works most of the time because we can guess the upcoming id. But recently, we switched to generated ids without dashes. This broke the challenge
