### PR TITLE
Add phantom blocks to next connections

### DIFF
--- a/app/elements/kano-app-challenge/kano-app-challenge.html
+++ b/app/elements/kano-app-challenge/kano-app-challenge.html
@@ -303,15 +303,18 @@
                 host;
             if (!phantom_block ||
                 !phantom_block.location ||
-                !phantom_block.target ||
                 !Blockly.selected) {
                 Blockly.removePhantomBlock();
                 return;
             }
             host = this.getTargetBlock(phantom_block.location.block);
-            for (let i = 0; i < host.inputList.length; i++) {
-                if (host.inputList[i].name === phantom_block.target) {
-                    connection = host.inputList[i].connection;
+            if (!phantom_block.target) {
+                connection = host.nextConnection;
+            } else {
+                for (let i = 0; i < host.inputList.length; i++) {
+                    if (host.inputList[i].name === phantom_block.target) {
+                        connection = host.inputList[i].connection;
+                    }
                 }
             }
             target = Blockly.selected;

--- a/app/scripts/kano/make-apps/challenge.js
+++ b/app/scripts/kano/make-apps/challenge.js
@@ -439,15 +439,15 @@
                             }
                         }
                     };
+                    step.phantom_block = {
+                        "location": {
+                            "block": parentSelector.id
+                        }
+                    };
                     if (parentSelector.inputName) {
-                        step.phantom_block = {
-                            "location": {
-                                "block": parentSelector.id
-                            },
-                            "target": parentSelector.inputName
-                        };
-                        steps.push(step);
+                        step.phantom_block.target =  parentSelector.inputName;
                     }
+                    steps.push(step);
                 } else {
                     steps.push({
                         "tooltips": [


### PR DESCRIPTION
Shows the phantom block in the next connection when no target is specified. Update the tutorial generation with this info.
