### PR TITLE
Default white color for lightboard.

### DIFF
--- a/app/scripts/mode/light.js
+++ b/app/scripts/mode/light.js
@@ -38,7 +38,7 @@ export default light = {
         javascript: (part) => {
             return (block) => {
                 let target = Blockly.JavaScript.valueToCode(block, 'TARGET') || '',
-                    color = Blockly.JavaScript.valueToCode(block, 'COLOR') || '""',
+                    color = Blockly.JavaScript.valueToCode(block, 'COLOR') || '"#ffffff"',
                     code = `devices.get('${part.id}').turnOn(${target}, ${color});\n`;
                 return code;
             };


### PR DESCRIPTION
Relate to [this card](https://trello.com/c/HWYCItQl/172-allow-lights-turn-on-to-work-without-color-specified)
