### PR TITLE
Add lightboard buttons

### DIFF
--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -38,10 +38,120 @@
         iron-image, #led-matrix {
             margin-top: -35px;
         }
+        .btn {
+            position: absolute;
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            border: 0px;
+            cursor: pointer;
+            background-color: transparent;
+        }
+        .btn:focus {
+            outline: none;
+            @apply(--shadow-elevation-2dp);
+        }
+        .btn.a {
+            top: 227px;
+            right: 19px;
+        }
+        .btn.b {
+            top: 227px;
+            right: 65px;
+        }
+        .joystick {
+            position: absolute;
+            width: 36px;
+            height: 36px;
+            border-radius: 50%;
+            cursor: pointer;
+            top: 228px;
+            left: 21px;
+            background-color: #4c4f55;
+            transition: transform cubic-bezier(0.2, 0, 0.13, 1.5) 150ms;
+            @apply(--layout-horizontal);
+            @apply(--layout-wrap);
+            overflow: hidden;
+            transform: rotate(45deg);
+        }
+        .joystick:hover {
+            transform: rotate(45deg) scale(2);
+        }
+        .joystick:not(:hover) .js-dir {
+            opacity: 0 !important;
+        }
+        .joystick:hover .js-dir {
+            opacity: 1;
+        }
+        .js-dir {
+            padding: 0px;
+            width: 50%;
+            height: 50%;
+            box-sizing: border-box;
+            transition: opacity cubic-bezier(0.2, 0, 0.13, 1.5) 150ms;
+            background-color: #3c3d3f;
+            border: 0px;
+            cursor: pointer;
+        }
+        .joystick button.js-dir:focus, .joystick button.js-dir:hover {
+            outline: none;
+            background-color: #45474c;
+        }
+        .js-dir.up, .js-dir.left {
+            margin-right: 1px;
+            width: calc(50% - 1px);
+        }
+        .js-dir.up, .js-dir.right {
+            margin-bottom: 1px;
+            height: calc(50% - 1px);
+        }
+        .js-dir .arrow-icon {
+            width: 3px;
+            height: 3px;
+            margin: 0 auto;
+            border-color: rgba(255, 255, 255, 0.7);
+            border-style: solid;
+            border-width: 0px;
+        }
+        .js-dir.up .arrow-icon {
+            border-top-width: 1px;
+            border-left-width: 1px;
+        }
+        .js-dir.right .arrow-icon {
+            border-top-width: 1px;
+            border-right-width: 1px;
+        }
+        .js-dir.down .arrow-icon {
+            border-bottom-width: 1px;
+            border-right-width: 1px;
+        }
+        .js-dir.left .arrow-icon {
+            border-bottom-width: 1px;
+            border-left-width: 1px;
+        }
+        .joystick button.js-dir:focus .arrow-icon, .joystick button.js-dir:hover .arrow-icon {
+            border-color: white;
+        }
     </style>
     <template>
         <iron-image src="/assets/mode/lightboard/body.svg" sizing="contain" width="[[width]]" height="[[height]]"></iron-image>
+        <button class="btn a" on-tap="_buttonATapped"></button>
+        <button class="btn b" on-tap="_buttonBTapped"></button>
         <kano-led-matrix id="led-matrix"></kano-led-matrix>
+        <div class="joystick">
+            <button class="js-dir up" on-tap="_joystickUpTapped">
+                <div class="arrow-icon"></div>
+            </button>
+            <button class="js-dir right" on-tap="_joystickRightTapped">
+                <div class="arrow-icon"></div>
+            </button>
+            <button class="js-dir left" on-tap="_joystickLeftTapped">
+                <div class="arrow-icon"></div>
+            </button>
+            <button class="js-dir down" on-tap="_joystickDownTapped">
+                <div class="arrow-icon"></div>
+            </button>
+        </div>
         <content></content>
     </template>
     <script>
@@ -91,6 +201,7 @@
                 let cb = this._keyDownCheck(key, callback);
                 this.userListeners.push({
                     name: 'button-down',
+                    key,
                     cb
                 });
                 Kano.AppModules.getModule('lightboard').on('button-down', cb);
@@ -101,6 +212,33 @@
                         callback();
                     }
                 };
+            },
+            _buttonTapped (key) {
+                this.userListeners.forEach(listener => {
+                    if (listener.name === 'button-down') {
+                        listener.cb({
+                            'button-id': key
+                        });
+                    }
+                });
+            },
+            _buttonATapped () {
+                this._buttonTapped('btn-A');
+            },
+            _buttonBTapped () {
+                this._buttonTapped('btn-B');
+            },
+            _joystickUpTapped () {
+                this._buttonTapped('js-up');
+            },
+            _joystickRightTapped () {
+                this._buttonTapped('js-right');
+            },
+            _joystickLeftTapped () {
+                this._buttonTapped('js-left');
+            },
+            _joystickDownTapped () {
+                this._buttonTapped('js-down');
             },
             stop () {
                 this.reset();


### PR DESCRIPTION
Related to https://trello.com/c/jNNGbU47/158-2-add-clickable-lightboard-buttons-to-the-ma-canvas-space

Base style:
![image](https://cloud.githubusercontent.com/assets/5550089/18002403/7e5f3fe2-6b7f-11e6-96cb-a8c2f28c317e.png)
On joystick hover:
![image](https://cloud.githubusercontent.com/assets/5550089/18002398/771269d0-6b7f-11e6-9c4e-4711789c8b61.png)
