### PR TITLE
Fix tutorial step validation.

### DIFF
--- a/app/elements/behaviors/kano-blockly-validator-behavior.html
+++ b/app/elements/behaviors/kano-blockly-validator-behavior.html
@@ -156,13 +156,32 @@
         _matchConnect (validation, event) {
             // Extract the validation object, target and parent step ids and
             // the block moved
-            let targetId = this.getTargetBlock(validation.target).id,
-                parentId = this.getTargetBlock(validation.parent).id;
+            let target = this.getTargetBlock(validation.target),
+                parent = this.getTargetBlock(validation.parent);
 
             // Check that the element moved is the one targeted and that its
             // new parent is the right one
-            if (event.blockId === targetId && event.newParentId === parentId) {
-                return true;
+            if (event.blockId === target.id && event.newParentId === parent.id) {
+                let connection;
+
+                if (!validation.parent.inputName) {
+                    connection = parent.nextConnection
+                } else {
+                    let input = parent.getInput(validation.parent.inputName)
+
+                    if (input) {
+                        connection = input.connection;
+                    } else {
+                        return false;
+                    }
+                }
+
+                if (!connection) {
+                    return false;
+                }
+
+                connection = connection.targetConnection;
+                return (connection.sourceBlock_.id === target.id);
             }
         },
         _matchDrop (validation, event) {
@@ -225,7 +244,7 @@
             } else {
                 connection = block.nextConnection;
             }
-            blockRect = block.svgGroup_.getBoundingClientRect();
+            blockRect = block.svgPath_.getBoundingClientRect();
             blockPos = block.getRelativeToSurfaceXY();
             inputRelPos = {
                 x: connection.x_ - blockPos.x,
@@ -247,9 +266,16 @@
         },
         _checkBlocklyEvent (validation, e) {
             let blocklyStep = validation,
-                detail = e.event;
+                detail = e.event,
+                block = this._blocklyWorkspace.getBlockById(detail.blockId);
             detail.type = this.eventsMap[detail.type] || detail.type;
+            if (detail.type === 'connect' && !detail.newParentId || (block && block.isShadow())) {
+                return;
+            }
             this._checkEvent(validation, detail);
+        },
+        setWorkspace (ws) {
+            this._blocklyWorkspace = ws;
         }
     };
 

--- a/app/elements/kano-app-challenge/kano-app-challenge.html
+++ b/app/elements/kano-app-challenge/kano-app-challenge.html
@@ -212,6 +212,10 @@
             this.editor = Polymer.dom(this.$.content).getDistributedNodes()[0];
             this.modal = this.$.modal;
             this.highlight = {};
+            this.editor.addEventListener('blockly-ready', (e) => {
+                let target = e.path ? e.path[0] : e.target;
+                this.setWorkspace(target.getWorkspace());
+            });
         },
         attached () {
             this.isAttached = true;
@@ -396,7 +400,7 @@
                     if (selector.block.inputName) {
                         return this.getTargetBlockInput(selector.block);
                     }
-                    return block.getSvgRoot();
+                    return block.svgPath_;
                 } else if (selector.category) {
                     let cat = selector.category;
                     if (cat.part) {

--- a/app/scripts/kano/make-apps/blockly/defaults.js
+++ b/app/scripts/kano/make-apps/blockly/defaults.js
@@ -91,7 +91,8 @@
             'UNIT': 'seconds'
         },
         'in_x_time': {
-            'DELAY': 1
+            'DELAY': 1,
+            'UNIT': 'seconds'
         },
         'repeat_x_times': {
             'N': 10


### PR DESCRIPTION
Related to [this Trello card](https://trello.com/c/WcJzdTd5/155-differentiate-between-block-inputs-in-the-tutorial-step-validation).

Most of the work was done by @paulvarache. Huge thumbs up for the time he spent to explain the logic and order of the execution.
