### PR TITLE
Prevent kano-app to be created twice

### DIFF
--- a/app/scripts/index.js
+++ b/app/scripts/index.js
@@ -8,6 +8,7 @@ var webComponentsSupported = ('registerElement' in document &&
     msg = 'Loading',
     loaded = false,
     loadEventFired = false,
+    kanoAppInserted = false,
     loadTimeoutId,
     started,
     timeout,
@@ -47,10 +48,14 @@ function startBreathing() {
 }
 
 function onElementsLoaded() {
+    if (kanoAppInserted) {
+        return;
+    }
     var app = document.createElement('kano-app'),
         loader = document.getElementById('loader');
     document.body.insertBefore(app, loader);
     document.addEventListener('kano-routing-load-finish', onFirstPageLoaded);
+    kanoAppInserted = true;
 }
 
 /**


### PR DESCRIPTION
Related to https://trello.com/c/1gsLdBlT/140-editor-loads-in-top-half-of-page-landing-page-remains-in-bottom-half
