### PR TITLE
Force a stop before a start, prevent multiple start being triggered

### DIFF
--- a/app/elements/behaviors/kano-editor-view-behavior.html
+++ b/app/elements/behaviors/kano-editor-view-behavior.html
@@ -26,6 +26,7 @@
                     if (!this.mode) {
                         return;
                     }
+                    Kano.AppModules.stop();
                     // Get the parts elements from the workspace
                     parts = this.$.editor.getWorkspace().getPartsDict();
                     // Tell AppModules where to find the parts


### PR DESCRIPTION
Fixes the bugs where the app wouldn't restart automatically and would keep to versions running at the same time
