### PR TITLE
Don't unset sticker when reassigning values

### DIFF
--- a/app/scripts/kano/make-apps/parts-api/sticker.html
+++ b/app/scripts/kano/make-apps/parts-api/sticker.html
@@ -12,7 +12,9 @@
                 return Kano.MakeApps.Files.generators.stickers(set, sticker);
             },
             setSticker (pic) {
-                this.set('model.userProperties.src', pic);
+                if (pic) {
+                    this.set('model.userProperties.src', pic);
+                }
             },
             getSource () {
                 return this.get('model.userProperties.src');


### PR DESCRIPTION
Related to: https://trello.com/c/ag1ZwrVQ/437-sticker-image-shouldn-t-vanish-when-in-edit-layout-mode
