### PR TITLE
Fixing various picture list glitches

### DIFF
--- a/app/elements/behaviors/kano-workspace-behavior.html
+++ b/app/elements/behaviors/kano-workspace-behavior.html
@@ -17,6 +17,7 @@
         },
         start () {},
         stop () {},
+        clear () {},
         renderOnCanvas () {
             return Promise.resolve();
         },

--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -313,6 +313,8 @@ Polymer({
         this.set('code', this._formatCode({}));
         this.set('background', getDefaultBackground());
         this.save();
+
+        this.$.workspace.reset();
     },
     closeDrawer () {
         this.$.partsPanel.closeDrawer();

--- a/app/elements/kano-workspace-camera/kano-workspace-camera.html
+++ b/app/elements/kano-workspace-camera/kano-workspace-camera.html
@@ -98,10 +98,12 @@
                 document.body.removeChild(a);
             },
             _updateFrame () {
-                this._paintFrame(this.pictures[this.frameId]);
-                this.frameId++;
-                if (this.frameId > this.pictures.length - 1) {
-                    this.frameId = 0;
+                if (this.pictures.length > 0) {
+                    this._paintFrame(this.pictures[this.frameId]);
+                    this.frameId++;
+                    if (this.frameId > this.pictures.length - 1) {
+                        this.frameId = 0;
+                    }
                 }
                 this.playingId = setTimeout(this._updateFrame.bind(this), 1000 / Math.max(1, this.speed));
             },
@@ -109,6 +111,7 @@
                 if (this.playingId) {
                     clearTimeout(this.playingId);
                     this.playingId = null;
+                    this.pictures = [];
                 }
             },
             _startWebcam () {
@@ -187,6 +190,10 @@
                     let url = URL.createObjectURL(blob);
                     this._saveFile(url, 'kano-code-gif.gif');
                 });
+            },
+            clear () {
+                this.pictures = [];
+                this.frameId = 0;
             },
             stop () {
                 this._pausePictureList();

--- a/app/elements/kano-workspace/kano-workspace.html
+++ b/app/elements/kano-workspace/kano-workspace.html
@@ -349,6 +349,9 @@
                 this.mode.workspace.viewport.width,
                 this.mode.workspace.viewport.height
             )
+        },
+        reset () {
+            this.dropzone.clear();
         }
     });
 </script>

--- a/app/scripts/kano/make-apps/parts-api/base.html
+++ b/app/scripts/kano/make-apps/parts-api/base.html
@@ -153,6 +153,7 @@
                             this.waiting[id]();
                         }
                         this.nextCall[id] = null;
+                        this.waiting[id] = null;
                     }, delay);
                     // Execute the callback
                     cb();


### PR DESCRIPTION
- Resetting the workspace didn't clear out the picture list which kept running
- A bug in the throttle function caused a glitch with repeated calls to wrong callbacks which redrew each frame with an old broken one.
