### PR TITLE
Fix Kano World.

### DIFF
--- a/app/scripts/kano/app-modules/app-modules.html
+++ b/app/scripts/kano/app-modules/app-modules.html
@@ -9,7 +9,7 @@
 
             config (config) {
                 Object.keys(this.modules).forEach(name => {
-                    if (this.modules[name] && this.modules[name].config) {
+                    if (this.modules[name] && this.modules[name].config && typeof this.modules[name].config === 'function') {
                         this.modules[name].config(config);
                     }
                 });


### PR DESCRIPTION
The error bellow it's thrown because of the support for older shares. The current fix prevents the error.

[ CONTROLLER ERROR ] TypeError: _this.modules[name].config is not a function
    at http://localhost:5000/external-play-bundle.js:5412:41
    at Array.forEach (native)
    at AppModules.config (http://localhost:5000/external-play-bundle.js:5411:43)
    at AppModules.init (http://localhost:5000/external-play-bundle.js:5423:29)
    at Function.init (http://localhost:5000/external-play-bundle.js:5537:42)
    at Vue.exports.init (http://localhost:5000/js/index.js:47827:29)
    at changeView (http://localhost:5000/js/index.js:8855:30)
    at Object.emit (http://localhost:5000/js/index.js:9948:21)
    at Object.Router.setRoute (http://localhost:5000/js/index.js:9244:11)
    at Object.Router.refresh (http://localhost:5000/js/index.js:9327:11)
