### PR TITLE
Renders normal image on 0 slices, make prism fullscreen

### DIFF
--- a/app/scripts/kano/make-apps/parts-api/kaleidoscope.html
+++ b/app/scripts/kano/make-apps/parts-api/kaleidoscope.html
@@ -9,11 +9,15 @@
         Prism = {
             transform (ctx, image, width, height, imageWidth, imageHeight, slices, zoom, offsetRotation, offsetScale, offsetX, offsetY) {
                 let step = 2 * Math.PI / slices,
-                    radius = Math.min(width, height) / 2,
+                    radius = Math.sqrt(Math.pow(width, 2) + Math.pow(height, 2)) / 2,
                     scale = zoom * (radius / Math.min(imageWidth, imageHeight)),
                     cx = imageWidth / 2,
                     centerX = width / 2 - radius,
                     centerY = height / 2 - radius;
+                if (slices === 0) {
+                    ctx.drawImage(image, 0, 0, width, height);
+                    return;
+                }
                 // Image could be in a broken state
                 try {
                     ctx.fillStyle = ctx.createPattern(image, 'repeat');


### PR DESCRIPTION
Related to https://trello.com/c/DUWz6R3P/516-slider-on-0-shows-nothing-in-the-picture
