### PR TITLE
Fix story lightboard without lights

### DIFF
--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -151,7 +151,7 @@
                 'update-shape': '_updateShape'
             },
             ready () {
-                this.set('bitmap', []);
+                this.set('bitmap', new Array(128));
             },
             attached () {
                 Kano.AppModules.getModule('lightboard').connect({


### PR DESCRIPTION
Related to [this Trello card](https://trello.com/c/0OZt309A/557-when-a-challenge-is-started-the-lightboard-renders-without-lights)
