### PR TITLE
Fix random scrollbars appearing when opening a dropdown in blockly

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -505,16 +505,12 @@ Polymer({
                 return 'Any unsaved changes to your app will be lost. Continue?';
             }
         }
-
-        document.body.style.overflow = 'hidden';
     },
     detached () {
         Kano.MakeApps.Parts.clear();
         this.detachEvents();
 
         window.onbeforeunload = null;
-
-        document.body.style.overflow = undefined;
     },
     _exportApp () {
         let savedApp = this.save(),

--- a/app/elements/kano-blockly/kano-blockly.html
+++ b/app/elements/kano-blockly/kano-blockly.html
@@ -230,9 +230,12 @@
                     }
                 }
             });
+
+            document.body.style.overflow = 'hidden';
         },
         detached () {
             this.workspace.dispose();
+            document.body.style.overflow = undefined;
         },
         _closeOmnibox (e) {
             if (!this._omniboxOpened) {


### PR DESCRIPTION
Blockly puts a div at  the end of body which it positions absolutely on the screen as the dropdown. This then causes random scrollbars popping up.

I hack will make sure that all views that have the editor in them disable scrolling on body to avoid this problem.

@paulvarache Is this too much of a hack?