### PR TITLE
Fixing gif generation in safari

### DIFF
--- a/app/elements/kano-share-modal/kano-share-modal.html
+++ b/app/elements/kano-share-modal/kano-share-modal.html
@@ -531,7 +531,8 @@
         },
         _onAppReady () {
             if (this.firstRender) {
-                setTimeout(this._generateAppGif.bind(this), 0)
+                /* setTimeout required on Safari */
+                setTimeout(this._generateAppGif.bind(this), 0);
             }
         },
         _generateAppGif () {


### PR DESCRIPTION
The component wasn't set before this signal gets fired which resulted in workspace being undefined.

This fixed that.