### PR TITLE
Adding a reset confirmation

### DIFF
--- a/app/elements/kano-side-menu/kano-side-menu.html
+++ b/app/elements/kano-side-menu/kano-side-menu.html
@@ -25,7 +25,6 @@
             width: 100%;
             height: 100%;
 
-            padding: 10px;
             @apply(--layout-horizontal);
             align-items: center;
 
@@ -34,7 +33,7 @@
             color: black;
             box-sizing: border-box;
         }
-        li:hover {
+        li a:hover {
             background: var(--color-grey-lightest);
         }
         li a {
@@ -43,6 +42,16 @@
 
             text-decoration: none;
             color: black;
+            padding: 10px;
+
+            background-color: #ffffff;
+
+            transition: transform 0.3s ease-in-out;
+
+            position: relative;
+        }
+        li a.reveal {
+            transform: translateX(71px);
         }
         li.user {
             @apply(--layout-horizontal);
@@ -90,6 +99,15 @@
         a>* {
             pointer-events: none;
         }
+        .reset-confirmation {
+            background-color: var(--color-red);
+            color: #ffffff;
+            padding: 10px;
+            position: absolute;
+        }
+        .reset-confirmation:hover {
+            background-color: var(--color-lighter-red);
+        }
     </style>
     <template>
         <ul>
@@ -111,7 +129,10 @@
                 </div>
             </li>
             <li>
-                <a on-tap="resetWorkspace">
+                <div on-tap="resetWorkspace" class="reset-confirmation">
+                    Confirm
+                </div>
+                <a on-tap="confirmReset" id="reset">
                     <iron-image class="icon" src="/assets/icons/reset.png" sizing="contain"></iron-image>
                     <div class="label">Reset Workspace</div>
                 </a>
@@ -230,12 +251,16 @@
             return !!this.user;
         },
         toggleMenu (e) {
+            this.$.reset.classList.remove('reveal');
             this.fire('toggle-menu', false);
             e.stopPropagation();
         },
-        resetWorkspace () {
+        confirmReset () {
+            this.$.reset.classList.toggle('reveal');
+        },
+        resetWorkspace (e) {
             this.fire('iron-signal', { name: 'reset-workspace' });
-            this.fire('toggle-menu', false);
+            this.toggleMenu(e)
         },
         /* FIXME: This was copied out of Kano World. We need to put this
                   functionality into the API. */

--- a/app/elements/kano-style/color.html
+++ b/app/elements/kano-style/color.html
@@ -10,6 +10,7 @@
         --color-blue: #59b3d0;
         --color-kw-blue: #54A2E3;
         --color-red: #e95c5a;
+        --color-lighter-red: #eb6c6a;
         --color-black: #333;
         --color-white: #f5f5f5;
         --color-grey: #7d7a73;


### PR DESCRIPTION
<img width="346" alt="screen shot 2016-11-14 at 16 18 45" src="https://cloud.githubusercontent.com/assets/169328/20272641/71554684-aa86-11e6-828f-c0efc57a59aa.png">

Used mobile-style reveal instead of a full dialog.

Related to: https://trello.com/c/b1EjfOM6/777-1-add-confirmation-step-when-resetting-the-kc-workspace