### PR TITLE
Fixed Sharecard on Facebook doesn't display image or description

### DIFF
--- a/app/elements/behaviors/kano-cover-generator-behavior.html
+++ b/app/elements/behaviors/kano-cover-generator-behavior.html
@@ -110,6 +110,7 @@
                 p = p.then(getFrame.bind(this));
             }
             return p.then(_ => {
+                images.unshift(images[images.length - 1]);
                 return new Promise((resolve, reject) => {
                     let gif = new GIF({
                         workers: 2,


### PR DESCRIPTION
found out facebook share dialog is not supporting gif, so it will only show the first frame, and I believe this post thumbnail first frame is blank.

Affect to new post only, generate new gif with full picture first frame
old post will not affect and need to be updated.

ticket:https://trello.com/c/7S4kb6xw/559-sharecard-on-facebook-doesn-t-display-image-or-description?menu=filter&filter=@arif148
