### PR TITLE
Fixed when text changed programatically, it should reset to its default value when in edit layout of paused modes.

### DIFF
--- a/app/elements/behaviors/kano-editor-view-behavior.html
+++ b/app/elements/behaviors/kano-editor-view-behavior.html
@@ -35,13 +35,13 @@
                     Kano.AppModules.loadParts(parts);
                     // Generate the code
                     appCode = Kano.AppModules.createAppCode('AppModules', this.code.snapshot.javascript);
-
+                    // Start all the modules. Will also trigger the `start` event from `global`
+                    Kano.AppModules.start();
                     // Prepare a sandbox exposing AppModules
                     vm = new Kano.VM({ AppModules: Kano.AppModules });
                     // Run the code
                     vm.runInContext(appCode);
-                    // Start all the modules. Will also trigger the `start` event from `global`
-                    Kano.AppModules.start();
+              
                 } else {
                     Kano.AppModules.stop();
                 }


### PR DESCRIPTION
Fixed when text changed programatically, it should reset to its default value when in edit layout of paused modes.
https://trello.com/c/Y84hyXdh/808-when-text-changed-programatically-it-should-reset-to-its-default-value-when-in-edit-layout-of-paused-modes?menu=filter&filter=@arif148
Problem:
The codeChange function always toggle code running, this cause the app state messy.
Solution:
Remove toggleRunning as no need in here. Press play/pause button instead running the code.