### PR TITLE
Moving neg margin so it doesn't get applied to standalone componnets

### DIFF
--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -5,7 +5,6 @@
 <dom-module id="kano-workspace-lightboard">
     <style>
         :host {
-            margin-top: -35px;
             display: block;
             width: 100%;
             height: 100%;

--- a/app/elements/kano-workspace/kano-workspace.html
+++ b/app/elements/kano-workspace/kano-workspace.html
@@ -75,6 +75,9 @@
         transform: translate(0, -9px);
         color: #eaeaea;
     }
+    :host kano-workspace-lightboard {
+        margin-top: -35px;
+    }
     .pause-overlay {
         position: absolute;
         top: 0px;


### PR DESCRIPTION
This negative margin got propagated to the share cards on KW and was buggering up the alignment of the lightboard in the viewport. It's specific to the use of the component inside kano-workspace only so I moved it there.

Before:

<img width="722" alt="screen shot 2016-11-18 at 16 39 54" src="https://cloud.githubusercontent.com/assets/169328/20438009/edb3177c-adad-11e6-962e-e284a0a0f146.png">


After:

<img width="728" alt="screen shot 2016-11-18 at 16 40 30" src="https://cloud.githubusercontent.com/assets/169328/20438018/f461b524-adad-11e6-9868-96d24877c084.png">
