### PR TITLE
Fixing bitmap refresh issue

### DIFF
--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -191,11 +191,7 @@
                 this.reset();
             },
             reset () {
-                let empty = [];
-                for (let i = 0; i < 128; i++) {
-                    empty.push('#000000');
-                }
-                this.render(empty);
+                this.clear();
             },
             getRestrictElement () {
                 return this.$['led-matrix'];

--- a/app/elements/kano-workspace/kano-workspace.html
+++ b/app/elements/kano-workspace/kano-workspace.html
@@ -546,7 +546,9 @@
             )
         },
         reset () {
-            this.dropzone.clear();
+            if (this.dropzone) {
+                this.dropzone.clear();
+            }
         },
         _runButtonClicked () {
             this.fire('run-button-clicked');

--- a/app/scripts/kano/app-modules/lightboard.html
+++ b/app/scripts/kano/app-modules/lightboard.html
@@ -23,6 +23,7 @@
                 this.addMethod('updateOrCreateShape', '_updateOrCreateShape');
                 this.addMethod('connect', '_connect');
                 this.addMethod('getBitmap', '_getBitmap');
+                this.addMethod('clear', '_clear');
             }
 
             config (opts) {
@@ -31,10 +32,10 @@
 
             _stop () {
                 this.lights = new Array(128);
+                this.bitmap = new Array(128);
                 this.shapes = {};
                 this.currentAnimation = null;
             }
-
             static getIndex (x, y) {
                 return LightboardModule.coordToIndex(x, y, 16);
             }
@@ -182,6 +183,12 @@
                     }, speed);
                 }
 
+            }
+
+            _clear (cb) {
+                this.lights = new Array(128);
+                this.bitmap = new Array(128);
+                this.updateAndSync(false, cb);
             }
 
             _scroll (text, color, backgroundColor, speed, callback) {

--- a/app/scripts/kano/make-apps/parts-api/lightboard.html
+++ b/app/scripts/kano/make-apps/parts-api/lightboard.html
@@ -20,6 +20,9 @@
                     this.appModules.getModule('lightboard').removeListener('button-down', this._propagateButtonEvent);
                 }
             },
+            clear () {
+                return this.appModules.getModule('lightboard').clear(this.render.bind(this));
+            },
             turnOn (light, color) {
                 return this.appModules.getModule('lightboard').turnOn(light, color, this.render.bind(this));
             },


### PR DESCRIPTION
The workspace wasn't flushing the bitmap properly which gave an impression that the play/stop mechanism is broken.

This fixes the problem. Related to: https://trello.com/c/Ss1NQVhd/789-kano-code-if-the-code-is-running-you-have-to-click-two-times-on-reset-for-it-reset-the-screen