### PR TITLE
Fixing the next challenge link in Safari

### DIFF
--- a/app/scripts/kano/make-apps/parts/parts.html
+++ b/app/scripts/kano/make-apps/parts/parts.html
@@ -33,7 +33,7 @@
                 return new this.partTypes[model.partType](model, size);
             },
             clear () {
-                return Part.clear();
+                return this.Part.clear();
             },
             init (c) {
                 let flags = c.getFlags();


### PR DESCRIPTION
The question is: how did this ever work?

@paulvarache: We also have this code in the repo twice (under `scripts/parts` and `scripts/kano/make-apps/parts`) Do we need to keep both?

Related to: https://trello.com/c/WC18g1qn/853-kano-code-go-to-next-story-on-webkit-on-kano-kit-just-produces-blank-page