### PR TITLE
Fixing lightboard positioning in screen caps

### DIFF
--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -208,7 +208,7 @@
                     let body = images[0],
                         led = images[1],
                         pixel;
-                    ctx.drawImage(body, 0, 0);
+                    ctx.drawImage(body, 0, 0, 466, 322);
                     ctx.save();
                     for (let i = 0, len = bitmap.length; i < len; i++) {
                         pixel = bitmap[i];


### PR DESCRIPTION
Lightboard positioning fix for safari: https://trello.com/c/vlBMSK8M/774-in-safari-and-on-kit-for-lightboard-gif-broken