### PR TITLE
Make the codespace more distinguishable on Kano Screen

### DIFF
--- a/app/elements/kano-style/themes/light.html
+++ b/app/elements/kano-style/themes/light.html
@@ -3,8 +3,9 @@
         --kano-blockly-background: white;
         --kano-blockly-toolbox-color: black;
         --kano-blockly-toolbox-selected-color: #f2f2f2;
-        --kano-app-editor-workspace-background: #cccccc;
-        --kano-app-editor-workspace-border: #6f6f6f;
+        --kano-app-editor-workspace-background: #263238;
+        --kano-app-editor-workspace-controls: #19111C;
+        --kano-app-editor-workspace-controls-hover: #261E2C;
 
         --kano-blockly-toolbox: {
             border-right: 1px solid #f2f2f2;

--- a/app/elements/kano-workspace-camera/kano-workspace-camera.html
+++ b/app/elements/kano-workspace-camera/kano-workspace-camera.html
@@ -19,9 +19,8 @@
             position: absolute;
             top: 0px;
             left: 0px;
-            width: calc(100% - 2px);
-            height: calc(100% - 2px);
-            border: 1px solid var(--kano-app-editor-workspace-border, #6f6f6f);
+            width: 100%;
+            height: 100%;
         }
         :host button {
             @apply(--kano-button);

--- a/app/elements/kano-workspace-head/kano-workspace-head.html
+++ b/app/elements/kano-workspace-head/kano-workspace-head.html
@@ -11,7 +11,7 @@
             position: relative;
 
             color: white;
-            background-color: #484848;
+            background-color: var(--kano-app-editor-workspace-controls, black);
             margin-right: 6px;
 
             display: flex;
@@ -58,7 +58,7 @@
             border-radius: 50%;
             border: none;
             color: white;
-            background-color: #484848;
+            background-color: var(--kano-app-editor-workspace-controls, black);
             margin-right: 6px;
             font-family: 'bariol';
             font-size: 14px;
@@ -71,8 +71,8 @@
             margin-right: 0px;
         }
         :host .head-controls button:hover {
-            transition: background-color .3s ease;
-            background-color: rgba(72, 72, 72, 0.8);
+            transition: opacity .3s ease;
+            background-color: var(--kano-app-editor-workspace-controls-hover, black);
         }
         :host .settings img {
             width: 20px;

--- a/app/elements/kano-workspace-normal/kano-workspace-normal.html
+++ b/app/elements/kano-workspace-normal/kano-workspace-normal.html
@@ -4,11 +4,10 @@
     <style>
         :host {
             display: block;
-            width: calc(100% - 2px);
-            height: calc(100% - 2px);
+            width: 100%;
+            height: 100%;
             background: #ffffff;
             border-radius: 5px;
-            border: 1px solid var(--kano-app-editor-workspace-border, #6f6f6f);
         }
         :host ::slotted(*:not(.hole)) {
             position: absolute;

--- a/app/elements/kano-workspace-toolbar/kano-workspace-toolbar.html
+++ b/app/elements/kano-workspace-toolbar/kano-workspace-toolbar.html
@@ -7,7 +7,7 @@
         }
         :host .panel {
             margin-top: 5px;
-            background-color: #484848;
+            background-color: var(--kano-app-editor-workspace-controls, black);
             border-radius: 5px;
             padding: 4px 4px;
 


### PR DESCRIPTION
Related to: https://trello.com/c/CU0oDSUj/900-kano-code-ui-make-colors-more-distinct

<img width="1272" alt="screen shot 2016-11-29 at 11 58 42" src="https://cloud.githubusercontent.com/assets/169328/20709124/536c9e64-b62b-11e6-98fe-e8bc91f1913b.png">
