### PR TITLE
Updates and optimisations for the onboarding reward modals

### DIFF
--- a/app/elements/kano-reward-modal/kano-reward-modal.html
+++ b/app/elements/kano-reward-modal/kano-reward-modal.html
@@ -1,12 +1,23 @@
+<link rel="import" href="../../bower_components/neon-animation/neon-animations.html">
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../../bower_components/iron-image/iron-image.html">
 <link rel="import" href="../../bower_components/paper-card/paper-card.html">
 <link rel="import" href="../../bower_components/iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../kano-style/kano-style.html">
 
 <dom-module id="kano-reward-modal">
     <style is="custom-style" include="input-text"></style>
     <style>
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(100%);
+            }
+
+            to {
+                opacity: 1;
+                transform: translateY(0%);
+            }
+        }
         :host {
             --color-background: #ffffff;
             --color-green: #5ac3ac;
@@ -17,30 +28,39 @@
             --color-dark-grey: #999999;
             --color-black: #000000;
             --color-text: #253541;
-            --border-radius-large: 10px;
-            --border-radius-medium: 5px;
+            --border-radius-large: 6px;
+            --border-radius-medium: 3px;
             background-color: transparent;
-            border-radius: var(--border-radius-large);
-            display: block;
-            position: relative;
-            font-family: Bariol;
-            /* It's bad practice to use !important but there is no other way
-            to remove the padding & margins without affecting other
-            paper-dialogs */
-            margin: 0px !important;
-            overflow: hidden;
-            padding: 0px !important;
+        }
+        :host paper-dialog {
+            background-color: transparent;
+        }
+        :host .fadeInUp {
+            animation-duration: 0.1s;
+            animation-name: fadeInUp;
+            animation-fill-mode: both;
         }
         :host .wrapper {
             background-color: var(--color-light-grey);
+            border-radius: var(--border-radius-large);
             color: var(--color-text);
-            padding-top: 90px;
+            display: block;
+            font-family: 'Bariol', sans-serif;
+            /* It's bad practice to use !important but there is no other way
+            to remove the padding & margins without affecting other
+            paper-dialogs */
+            margin: 0 !important;
+            overflow: hidden;
+            padding-bottom: 0 !important;
+            padding-left: 0 !important;
+            padding-right: 0 !important;
+            position: relative;
         }
         :host .content {
             background-color: var(--color-background);
             box-sizing: border-box;
-            max-width: 400px;
-            padding: 0 60px 30px 60px;
+            padding-left: 0;
+            padding-right: 0;
             position: relative;
             text-align: center;
         }
@@ -52,7 +72,7 @@
             position: absolute;
             right: 0;
             top: 0;
-            transform: translateY(-50%);
+            transform: translateY(-65%);
             width: 130px;
         }
         :host .wrapper.wrapper--green .motif-component--fill {
@@ -78,7 +98,8 @@
             font-weight: bold;
             line-height: 1.2em;
             margin: 0;
-            padding: 65px 20px 12px 20px;
+            padding-bottom: 12px;
+            padding-top: 55px;
         }
         :host .body {
             color: var(--color-dark-grey);
@@ -86,37 +107,43 @@
             font-weight: bold;
             line-height: 1.2em;
             margin: 0;
-            padding: 0px 20px 25px 20px;
-        }
-        :host .xp::before {
-            color: var(--color-yellow);
-            content: '+';
-            display: inline-block;
-            font-size: 28px;
-            line-height: 1em;
-            vertical-align: 35%;
+            padding-bottom: 25px;
+            padding-top: 0px;
         }
         :host .xp {
             border-bottom: 2px solid var(--color-light-grey);
             border-top: 2px solid var(--color-light-grey);
-            display: inline-block;
-            font-size: 46px;
-            font-weight: bold;
-            padding: 18px 20px;
+            margin: 0 auto;
+            max-width: 190px;
+            padding: 10px 7px;
             text-align: center;
         }
-        :host .xp::after {
+        :host .xp-prefix {
+            color: var(--color-yellow);
+            display: inline-block;
+            font-size: 28px;
+            line-height: 1em;
+            margin-right: 15px;
+            vertical-align: 15%;
+        }
+        :host .xp-value {
+            display: inline-block;
+            font-size: 36px;
+            font-weight: bold;
+        }
+        :host .xp-suffix {
             background-color: var(--color-yellow);
             border-radius: var(--border-radius-large);
             color: var(--color-background);
-            content: 'xp';
             display: inline-block;
-            font-size: 22px;
-            padding: 8px;
+            font-size: 16px;
+            margin-left: 15px;
+            padding: 6px;
             text-transform: uppercase;
-            vertical-align: 35%;
+            vertical-align: 30%;
         }
         :host .action {
+            padding-bottom: 0;
             padding-top: 20px;
         }
         :host .button {
@@ -137,9 +164,22 @@
             color: var(--color-background);
             padding: 14px 24px;
         }
+        :host .button .icon {
+            display: inline-block;
+            height: auto;
+            line-height: 0;
+            opacity: 0.3;
+            vertical-align: top;
+            width: 20px;
+        }
+        :host .button .icon ~ .action-text {
+            margin-left: 10px;
+        }
+        :host .button .action-text ~ .icon {
+            margin-left: 10px;
+        }
         :host .button.button--primary .icon {
             color: var(--color-black);
-            opacity: 0.3;
         }
         :host .wrapper.wrapper--green .button.button--primary {
             background-color: var(--color-green);
@@ -155,74 +195,120 @@
             color: var(--color-medium-grey);
             padding: 12px 20px;
         }
-        :host .icon {
-            display: inline-block;
-            font-size: 22px;
-            font-family: 'ui-font-solid';
-            font-style: normal;
-            font-weight: normal;
-            font-variant: normal;
-            line-height: 1;
-            speak: none;
-            text-transform: none;
-            vertical-align: -2px;
-
-            /* Enable Ligatures ================ */
-            -webkit-font-feature-settings: "liga";
-            -moz-font-feature-settings: "liga=1";
-            -moz-font-feature-settings: "liga";
-            -ms-font-feature-settings: "liga" 1;
-            -o-font-feature-settings: "liga";
-            font-feature-settings: "liga";
-
-            /* Better Font Rendering =========== */
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
-        }
-        :host .icon-arrow-up:before {
-            content: '\E112';
-        }
-        :host .icon-floppy-disc:before {
-            content: '\E312';
-        }
-        :host .icon-arrow-up.icon-arrow-right {
+        :host .icon-arrow-up.icon-arrow-right svg {
             transform: rotate(90deg);
+        }
+        :host .xp-component {
+            opacity: 0;
+        }
+        :host .xp-component:nth-child(2) {
+            animation-delay: 0.025s;
+        }
+        :host .xp-component:nth-child(3) {
+            animation-delay: 0.05s;
+        }
+        @media all and (max-width: 580px) {
+            :host .wrapper {
+                padding-top: 100px !important;
+                width: 300px;
+            }
+            :host .content {
+                padding-bottom: 20px;
+            }
+            :host .title,
+            :host .body,
+            :host .action {
+                padding-left: 20px;
+                padding-right: 20px;
+            }
+        }
+        @media all and (min-width: 580px) {
+            :host .wrapper {
+                padding-top: 120px !important;
+                width: 380px;
+            }
+            :host .content {
+                padding-bottom: 50px;
+            }
+            :host .title,
+            :host .body,
+            :host .action {
+                padding-left: 50px;
+                padding-right: 50px;
+            }
         }
     </style>
     <template>
-        <div class$="[[_wrapperClass(content.color)]]">
-            <div class="content">
-                <div class="motif">
-                    <template is="dom-if" if="[[_iconType('heart', content.icon)]]">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 137"><defs><style>.cls-1{isolation:isolate;}.cls-2,.cls-3,.cls-4{fill:none;stroke-miterlimit:10;}.cls-2{stroke-width:1.96px;opacity:0.4;}.cls-3{stroke-width:5.55px;opacity:0.8;}.cls-4{stroke-width:3.6px;opacity:0.6;}.cls-5{}.cls-6{mix-blend-mode:multiply;}.cls-7{fill:#ccc;}.cls-8{fill:#fff;}</style></defs><title>Heart</title><g class="cls-1"><g id="Layer_1" data-name="Layer 1"><circle class="cls-2" cx="68.49" cy="68.92" r="66.39"/><circle class="cls-3 motif-component motif-component--stroke" cx="68.49" cy="68.92" r="49.24"/><circle class="cls-4 motif-component motif-component--stroke" cx="68.49" cy="68.92" r="58.72"/><circle class="cls-5 motif-component motif-component--fill" cx="68.33" cy="69.11" r="41.53"/><g class="cls-6"><path class="cls-7" d="M78.33,53.77a10.88,10.88,0,0,0-10,6.64,10.87,10.87,0,0,0-10-6.64c-7.47,0-12,7.13-12,13,0,9.84,22,24.85,22,24.85s22-15,22-24.84C90.31,60.9,85.81,53.77,78.33,53.77Z"/></g><path class="cls-8" d="M78.33,50.62a10.88,10.88,0,0,0-10,6.64,10.87,10.87,0,0,0-10-6.64c-7.47,0-12,7.13-12,13,0,9.84,22,24.85,22,24.85s22-15,22-24.84C90.31,57.74,85.81,50.62,78.33,50.62Z"/></g></g></svg>
-                    </template>
-                    <template is="dom-if" if="[[_iconType('star', content.icon)]]">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 137"><defs><style>.cls-1{isolation:isolate;}.cls-2,.cls-3,.cls-4{fill:none;stroke-miterlimit:10;}.cls-2{stroke-width:1.96px;opacity:0.4;}.cls-3{stroke-width:5.55px;opacity:0.8;}.cls-4{stroke-width:3.6px;opacity:0.6;}.cls-5{}.cls-6{fill:#ccc;mix-blend-mode:multiply;}.cls-7{fill:#fff;}</style></defs><title>Star</title><g class="cls-1"><g id="Layer_1" data-name="Layer 1"><circle class="cls-2" cx="68.77" cy="68.73" r="66.39"/><circle class="cls-3 motif-component motif-component--stroke" cx="68.77" cy="68.73" r="49.24"/><circle class="cls-4 motif-component motif-component--stroke" cx="68.77" cy="68.73" r="58.72"/><circle class="cls-5 motif-component motif-component--fill" cx="68.77" cy="68.73" r="41.53"/><path class="cls-6" d="M80.49,88.23a3.08,3.08,0,0,1-1,.16A3.44,3.44,0,0,1,78.06,88l-9.37-4.86-9.33,5a2.92,2.92,0,0,1-.49.22,3.13,3.13,0,0,1-2.78-.4,3.19,3.19,0,0,1-1.26-3.06l1.72-10.45-7.66-7.32A3.11,3.11,0,0,1,50,62a3,3,0,0,1,.54-.13l10.49-1.6,4.58-9.54a3.12,3.12,0,0,1,1.8-1.58,3.15,3.15,0,0,1,3.82,1.56L76,60.17l10.49,1.44A3.1,3.1,0,0,1,89,63.69a3.17,3.17,0,0,1-.8,3.18l-7.52,7.46,1.88,10.4a3.15,3.15,0,0,1-2.07,3.5"/><path class="cls-7" d="M80.49,85a3.08,3.08,0,0,1-1,.16,3.44,3.44,0,0,1-1.46-.35l-9.37-4.86-9.33,5a2.92,2.92,0,0,1-.49.22,3.13,3.13,0,0,1-2.78-.4,3.19,3.19,0,0,1-1.26-3.06l1.72-10.45-7.66-7.32A3.11,3.11,0,0,1,50,58.76a3,3,0,0,1,.54-.13L61.05,57l4.58-9.54a3.12,3.12,0,0,1,1.8-1.58,3.15,3.15,0,0,1,3.82,1.56L76,56.94l10.49,1.44A3.1,3.1,0,0,1,89,60.46a3.17,3.17,0,0,1-.8,3.18l-7.52,7.46,1.88,10.4A3.15,3.15,0,0,1,80.49,85"/></g></g></svg>
-                    </template>
-                    <template is="dom-if" if="[[_iconType('tick', content.icon)]]">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 137"><defs><style>.cls-1{isolation:isolate;}.cls-2,.cls-3,.cls-4{fill:none;stroke-miterlimit:10;}.cls-2{stroke-width:1.96px;opacity:0.4;}.cls-3{stroke-width:5.55px;opacity:0.8;}.cls-4{stroke-width:3.6px;opacity:0.6;}.cls-5{}.cls-6{fill:#ccc;mix-blend-mode:multiply;}.cls-7{fill:#fff;}</style></defs><title>Tick</title><g class="cls-1"><g id="Layer_1" data-name="Layer 1"><circle class="cls-2" cx="68.72" cy="68.4" r="66.39"/><circle class="cls-3 motif-component motif-component--stroke" cx="68.72" cy="68.4" r="49.24"/><circle class="cls-4 motif-component motif-component--stroke" cx="68.72" cy="68.4" r="58.72"/><circle class="cls-5 motif-component motif-component--fill" cx="68.88" cy="68.4" r="41.53"/><path class="cls-6" d="M63.72,88.17a2.12,2.12,0,0,1-1.62.68,2.24,2.24,0,0,1-1.65-.68l-2.24-2.24a2.36,2.36,0,0,1,0-3.27l26-26a2.12,2.12,0,0,1,2.22-.6,2.23,2.23,0,0,1,1.05.6l2.24,2.24a2.15,2.15,0,0,1,.62,2.24,2,2,0,0,1-.62,1ZM47.34,74.8a2.36,2.36,0,0,1,0-3.27l2.24-2.24a2.25,2.25,0,0,1,1.65-.68,2.13,2.13,0,0,1,1.62.68L66,82.5a2.13,2.13,0,0,1,.68,1.62A2.25,2.25,0,0,1,66,85.77L63.81,88a2.36,2.36,0,0,1-3.27,0Z"/><path class="cls-7" d="M63.72,85.17a2.12,2.12,0,0,1-1.62.68,2.24,2.24,0,0,1-1.65-.68l-2.24-2.24a2.36,2.36,0,0,1,0-3.27l26-26a2.12,2.12,0,0,1,2.22-.6,2.23,2.23,0,0,1,1.05.6l2.24,2.24a2.15,2.15,0,0,1,.62,2.24,2,2,0,0,1-.62,1ZM47.34,71.8a2.36,2.36,0,0,1,0-3.27l2.24-2.24a2.25,2.25,0,0,1,1.65-.68,2.13,2.13,0,0,1,1.62.68L66,79.5a2.13,2.13,0,0,1,.68,1.62A2.25,2.25,0,0,1,66,82.77L63.81,85a2.36,2.36,0,0,1-3.27,0Z"/></g></g></svg>
-                    </template>
-                </div>
-                <h3 class="title">{{content.title}}</h3>
-                <p class="body">{{content.body}}</p>
-                <div class="xp">
-                  {{content.xp}}
-                </div>
-                <template is="dom-repeat" items={{content.links}} as="link">
-                    <div class="action">
-                        <button class$="[[_buttonClass(index)]]" on-tap="_handleTap">
-                            <template is="dom-if" if="[[_iconType('save', link.type)]]">
-                                <div class="icon icon-floppy-disc"></div>
-                            </template>
-                            {{link.text}}
-                            <template is="dom-if" if="[[_iconType('progress', link.type)]]">
-                                <div class="icon icon-arrow-up icon-arrow-right"></div>
-                            </template>
-                        </button>
+        <paper-dialog
+            entry-animation="slide-from-bottom-animation"
+            id="reward-modal-dialog"
+            on-iron-overlay-opened="_updateModalVisibility"
+            on-iron-overlay-closed="_updateModalVisibility"
+            with-backdrop>
+            <div class$="[[_wrapperClass(content.color)]]">
+                <div class="content">
+                    <div class="motif">
+                        <template is="dom-if" if="[[_iconType('heart', content.icon)]]">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 137"><defs><style>.cls-1{isolation:isolate;}.cls-2,.cls-3,.cls-4{fill:none;stroke-miterlimit:10;}.cls-2{stroke-width:1.96px;opacity:0.4;}.cls-3{stroke-width:5.55px;opacity:0.8;}.cls-4{stroke-width:3.6px;opacity:0.6;}.cls-5{}.cls-6{mix-blend-mode:multiply;}.cls-7{fill:#ccc;}.cls-8{fill:#fff;}</style></defs><title>Heart</title><g class="cls-1"><g id="Layer_1" data-name="Layer 1"><circle class="cls-2" cx="68.49" cy="68.92" r="66.39"/><circle class="cls-3 motif-component motif-component--stroke" cx="68.49" cy="68.92" r="49.24"/><circle class="cls-4 motif-component motif-component--stroke" cx="68.49" cy="68.92" r="58.72"/><circle class="cls-5 motif-component motif-component--fill" cx="68.33" cy="69.11" r="41.53"/><g class="cls-6"><path class="cls-7" d="M78.33,53.77a10.88,10.88,0,0,0-10,6.64,10.87,10.87,0,0,0-10-6.64c-7.47,0-12,7.13-12,13,0,9.84,22,24.85,22,24.85s22-15,22-24.84C90.31,60.9,85.81,53.77,78.33,53.77Z"/></g><path class="cls-8" d="M78.33,50.62a10.88,10.88,0,0,0-10,6.64,10.87,10.87,0,0,0-10-6.64c-7.47,0-12,7.13-12,13,0,9.84,22,24.85,22,24.85s22-15,22-24.84C90.31,57.74,85.81,50.62,78.33,50.62Z"/></g></g></svg>
+                        </template>
+                        <template is="dom-if" if="[[_iconType('star', content.icon)]]">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 137"><defs><style>.cls-1{isolation:isolate;}.cls-2,.cls-3,.cls-4{fill:none;stroke-miterlimit:10;}.cls-2{stroke-width:1.96px;opacity:0.4;}.cls-3{stroke-width:5.55px;opacity:0.8;}.cls-4{stroke-width:3.6px;opacity:0.6;}.cls-5{}.cls-6{fill:#ccc;mix-blend-mode:multiply;}.cls-7{fill:#fff;}</style></defs><title>Star</title><g class="cls-1"><g id="Layer_1" data-name="Layer 1"><circle class="cls-2" cx="68.77" cy="68.73" r="66.39"/><circle class="cls-3 motif-component motif-component--stroke" cx="68.77" cy="68.73" r="49.24"/><circle class="cls-4 motif-component motif-component--stroke" cx="68.77" cy="68.73" r="58.72"/><circle class="cls-5 motif-component motif-component--fill" cx="68.77" cy="68.73" r="41.53"/><path class="cls-6" d="M80.49,88.23a3.08,3.08,0,0,1-1,.16A3.44,3.44,0,0,1,78.06,88l-9.37-4.86-9.33,5a2.92,2.92,0,0,1-.49.22,3.13,3.13,0,0,1-2.78-.4,3.19,3.19,0,0,1-1.26-3.06l1.72-10.45-7.66-7.32A3.11,3.11,0,0,1,50,62a3,3,0,0,1,.54-.13l10.49-1.6,4.58-9.54a3.12,3.12,0,0,1,1.8-1.58,3.15,3.15,0,0,1,3.82,1.56L76,60.17l10.49,1.44A3.1,3.1,0,0,1,89,63.69a3.17,3.17,0,0,1-.8,3.18l-7.52,7.46,1.88,10.4a3.15,3.15,0,0,1-2.07,3.5"/><path class="cls-7" d="M80.49,85a3.08,3.08,0,0,1-1,.16,3.44,3.44,0,0,1-1.46-.35l-9.37-4.86-9.33,5a2.92,2.92,0,0,1-.49.22,3.13,3.13,0,0,1-2.78-.4,3.19,3.19,0,0,1-1.26-3.06l1.72-10.45-7.66-7.32A3.11,3.11,0,0,1,50,58.76a3,3,0,0,1,.54-.13L61.05,57l4.58-9.54a3.12,3.12,0,0,1,1.8-1.58,3.15,3.15,0,0,1,3.82,1.56L76,56.94l10.49,1.44A3.1,3.1,0,0,1,89,60.46a3.17,3.17,0,0,1-.8,3.18l-7.52,7.46,1.88,10.4A3.15,3.15,0,0,1,80.49,85"/></g></g></svg>
+                        </template>
+                        <template is="dom-if" if="[[_iconType('tick', content.icon)]]">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 137 137"><defs><style>.cls-1{isolation:isolate;}.cls-2,.cls-3,.cls-4{fill:none;stroke-miterlimit:10;}.cls-2{stroke-width:1.96px;opacity:0.4;}.cls-3{stroke-width:5.55px;opacity:0.8;}.cls-4{stroke-width:3.6px;opacity:0.6;}.cls-5{}.cls-6{fill:#ccc;mix-blend-mode:multiply;}.cls-7{fill:#fff;}</style></defs><title>Tick</title><g class="cls-1"><g id="Layer_1" data-name="Layer 1"><circle class="cls-2" cx="68.72" cy="68.4" r="66.39"/><circle class="cls-3 motif-component motif-component--stroke" cx="68.72" cy="68.4" r="49.24"/><circle class="cls-4 motif-component motif-component--stroke" cx="68.72" cy="68.4" r="58.72"/><circle class="cls-5 motif-component motif-component--fill" cx="68.88" cy="68.4" r="41.53"/><path class="cls-6" d="M63.72,88.17a2.12,2.12,0,0,1-1.62.68,2.24,2.24,0,0,1-1.65-.68l-2.24-2.24a2.36,2.36,0,0,1,0-3.27l26-26a2.12,2.12,0,0,1,2.22-.6,2.23,2.23,0,0,1,1.05.6l2.24,2.24a2.15,2.15,0,0,1,.62,2.24,2,2,0,0,1-.62,1ZM47.34,74.8a2.36,2.36,0,0,1,0-3.27l2.24-2.24a2.25,2.25,0,0,1,1.65-.68,2.13,2.13,0,0,1,1.62.68L66,82.5a2.13,2.13,0,0,1,.68,1.62A2.25,2.25,0,0,1,66,85.77L63.81,88a2.36,2.36,0,0,1-3.27,0Z"/><path class="cls-7" d="M63.72,85.17a2.12,2.12,0,0,1-1.62.68,2.24,2.24,0,0,1-1.65-.68l-2.24-2.24a2.36,2.36,0,0,1,0-3.27l26-26a2.12,2.12,0,0,1,2.22-.6,2.23,2.23,0,0,1,1.05.6l2.24,2.24a2.15,2.15,0,0,1,.62,2.24,2,2,0,0,1-.62,1ZM47.34,71.8a2.36,2.36,0,0,1,0-3.27l2.24-2.24a2.25,2.25,0,0,1,1.65-.68,2.13,2.13,0,0,1,1.62.68L66,79.5a2.13,2.13,0,0,1,.68,1.62A2.25,2.25,0,0,1,66,82.77L63.81,85a2.36,2.36,0,0,1-3.27,0Z"/></g></g></svg>
+                        </template>
                     </div>
-                </template>
+                    <h3 class="title">{{content.title}}</h3>
+                    <p class="body">{{content.body}}</p>
+                    <div class="xp">
+                      <span class="xp-component xp-prefix">+</span>
+                      <span class="xp-component xp-value">{{content.xp}}</span>
+                      <span class="xp-component xp-suffix">xp</span>
+                    </div>
+                    <template is="dom-repeat" items={{content.links}} as="link">
+                        <div class="action">
+                            <button class$="[[_buttonClass(index)]]" on-tap="_handleTap">
+                                <template is="dom-if" if="[[_iconType('save', link.type)]]">
+                                  <div class="icon icon-floppy-disc">
+                                      <?xml version="1.0" encoding="utf-8"?>
+                                      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 90 90" style="enable-background:new 0 0 90 90;" xml:space="preserve">
+                                        <g>
+                                          <g>
+                                            <path
+                                              d="M64.3,36.8V16.1c0-0.8,0.3-1.4,0.8-1.9c0.5-0.5,1.2-0.8,1.9-0.8h5.5c1.2,0,2.1,0.4,2.9,1.2c0.8,0.8,1.1,1.7,1.1,2.9v55
+                                            c0,1.2-0.4,2.1-1.1,2.9c-0.8,0.8-1.7,1.2-2.9,1.2h-55c-1.2,0-2.1-0.4-2.9-1.2c-0.8-0.8-1.2-1.7-1.2-2.9V26.8
+                                            c0-1.1,0.4-2.1,1.2-2.8l9.6-9.6c0.6-0.6,1.4-0.9,2.3-0.9H28c0.8,0,1.4,0.3,1.9,0.8c0.5,0.5,0.8,1.2,0.8,1.9v20.6
+                                            c0,0.7,0.3,1.4,0.8,1.9c0.5,0.5,1.2,0.8,1.9,0.8h28.1c0.8,0,1.4-0.3,1.9-0.8C64,38.1,64.3,37.5,64.3,36.8z M39.1,33.1
+                                            c-0.8,0-1.4-0.3-1.9-0.8c-0.5-0.5-0.8-1.2-0.8-1.9V16.1c0-0.8,0.3-1.4,0.8-1.9c0.5-0.5,1.2-0.8,1.9-0.8h5.4c0.8,0,1.4,0.3,1.9,0.8
+                                            c0.5,0.5,0.8,1.2,0.8,1.9v14.3c0,0.8-0.3,1.4-0.8,1.9c-0.5,0.5-1.2,0.8-1.9,0.8H39.1z"/>
+                                          </g>
+                                        </g>
+                                      </svg>
+                                    </div>
+                                </template>
+                                <span class="action-text">{{link.text}}</span>
+                                <template is="dom-if" if="[[_iconType('progress', link.type)]]">
+                                    <div class="icon icon-arrow-up icon-arrow-right">
+                                      <?xml version="1.0" encoding="utf-8"?>
+                                      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                                         viewBox="0 0 90 90" style="enable-background:new 0 0 90 90;" xml:space="preserve">
+                                      <g>
+                                        <g>
+                                          <path d="M28.3,47.4h-9.7c-1.3,0-2.3-0.6-2.9-1.8c-0.6-1.2-0.4-2.3,0.4-3.4l25.5-30.6c0.9-1,2-1.5,3.3-1.5c1.3,0,2.4,0.5,3.3,1.5
+                                            l25.5,30.6c0.9,1.1,1,2.2,0.4,3.4c-0.6,1.2-1.5,1.8-2.9,1.8h-9.8c-1.2,0-2.2,0.4-3.1,1.2c-0.8,0.8-1.2,1.9-1.2,3.1v23.5
+                                            c0,1.3-0.4,2.4-1.3,3.3c-0.9,0.9-2,1.3-3.3,1.3H37.2c-1.3,0-2.4-0.4-3.3-1.3c-0.9-0.9-1.3-2-1.3-3.3V51.8c0-1.2-0.4-2.2-1.2-3.1
+                                            C30.6,47.9,29.5,47.4,28.3,47.4z"/>
+                                        </g>
+                                      </g>
+                                      </svg>
+                                    </div>
+                                </template>
+                            </button>
+                        </div>
+                    </template>
+                </div>
             </div>
-        </div>
+        </paper-dialog>
     </template>
 </dom-module>
 
@@ -233,10 +319,27 @@
         properties: {
             content: {
                 type: Object
+            },
+            modalVisibility: {
+                type: Boolean,
+                value: false
             }
         },
-        attached () {},
-        dettached () {},
+        observers: [
+            '_onVisibilityChanged(modalVisibility)'
+        ],
+        attached () {
+            this.$['reward-modal-dialog'].backdropElement.classList.add('reward');
+        },
+        deattached () {
+            this.$['reward-modal-dialog'].backdropElement.classList.remove('reward');
+        },
+        open () {
+            this.$['reward-modal-dialog'].open();
+        },
+        close () {
+            this.$['reward-modal-dialog'].close();
+        },
         _buttonClass (index) {
             if (index === 0) {
                 return `button button--primary`;
@@ -244,12 +347,27 @@
             return 'button button--secondary';
         },
         _handleTap (e) {
+            this.close();
             this.fire('interaction', {
                 type: e.model.link.type
             });
         },
         _iconType (icon, content) {
             return icon === content;
+        },
+        _onVisibilityChanged (visible) {
+            let xpComponents = Polymer.dom(this.root).querySelectorAll('.xp-component');
+            let xpArray = Array.prototype.slice.call(xpComponents);
+            for (let i = 0; i < xpArray.length; i++) {
+                if (visible) {
+                    xpArray[i].classList.add('fadeInUp');
+                } else {
+                    xpArray[i].classList.remove('fadeInUp');
+                }
+            }
+        },
+        _updateModalVisibility () {
+            this.set('modalVisibility', !this.modalVisibility);
         },
         _wrapperClass (color) {
             return `wrapper wrapper--${color || "default"}`

--- a/app/elements/kano-style/kano-style.html
+++ b/app/elements/kano-style/kano-style.html
@@ -32,4 +32,9 @@
             box-shadow: inset 4px 0 5px 0 rgba(0, 0, 0, 0.14);
         }
     }
+
+    iron-overlay-backdrop.reward {
+        --iron-overlay-backdrop-opacity: 1;
+        --iron-overlay-backdrop-background-color: #5c6870;
+    }
 </style>

--- a/app/elements/kano-style/typography.html
+++ b/app/elements/kano-style/typography.html
@@ -56,15 +56,6 @@
     font-weight: 100;
     font-style: italic;
 }
-@font-face {
-    font-family: 'ui-font-solid';
-    src: url('/assets/fonts/uifont-solid.eot');
-    src: url('/assets/fonts/uifont-solid.eot?#iefix') format('embedded-opentype'),
-         url('/assets/fonts/uifont-solid.ttf') format('truetype'),
-         url('/assets/fonts/uifont-solid.svg') format('svg');
-    font-weight: normal;
-    font-style: normal;
-}
 
 html {
     --font-heading: 'Bariol', Helvetica, Arial, sans-serif;

--- a/app/views/kano-view-onboarding/kano-view-onboarding.html
+++ b/app/views/kano-view-onboarding/kano-view-onboarding.html
@@ -17,10 +17,6 @@
     :host kano-app-editor {
         @apply(--layout-flex);
     }
-    :host paper-dialog {
-        background: transparent;
-        overflow: hidden;
-    }
     </style>
     <template>
         <kano-app-editor
@@ -35,13 +31,10 @@
             challenge-state="{{challengeState}}"
             on-fireworks-triggered="_stageFinished"
             on-talking-face-animation-stopped="_stageFinished"></kano-app-editor>
-        <paper-dialog
+        <kano-reward-modal
+            content="[[_currentReward(stageNo)]]"
             id="reward-modal"
-            with-backdrop>
-            <kano-reward-modal
-                on-interaction='_handleModalAction'
-                content='[[_currentReward(stageNo)]]'></kano-reward-modal>
-        </paper-dialog>
+            on-interaction="_handleModalAction"></kano-reward-modal>
     </template>
 </dom-module>
 
@@ -102,9 +95,6 @@
                                 links: [{
                                     text: 'Try second challenge',
                                     type: 'progress'
-                                }, {
-                                    text: 'Save',
-                                    type: 'save'
                                 }],
                                 xp: 100
                             }
@@ -134,9 +124,6 @@
                                 links: [{
                                     text: 'Try last challenge',
                                     type: 'progress'
-                                }, {
-                                    text: 'Save',
-                                    type: 'save'
                                 }],
                                 xp: 200
                             }
@@ -252,8 +239,6 @@
             return this.stages[stageNo].reward;
         },
         _handleModalAction (e) {
-            this.$['reward-modal'].close();
-
             if (e.detail.type === 'save') {
                 this.fire('signup');
             } else if (e.detail.type ==='progress' && this.stageNo === 2) {


### PR DESCRIPTION
* Remove onboarding-specific icon font from KC and replace it with standalone SVG icons (Trello card: https://trello.com/c/5pQ4IX6n/922-1-remove-onboarding-specific-icon-font-from-kc-and-replace-it-with-standalone-svg-icons)
* Update Reward Modal design (Trello card: https://trello.com/c/BIqajZnF/933-2-onboarding-modal-design-details):
        * Make background fully opaque (adds a class to the iron-overlay-backdrop to allow this, since the variables cannot be passed down)
        * Spaces out the XP elements
        * Removes Save button from the first two onboarding modals
        * Changes the scale and padding of the modal to work better on smaller screens
* Animat the Reward Modal to slide in from the bottom, and the XP elements to slide/fade in, one after the other (Trello card: https://trello.com/c/JrMpxscK/935-1-onboarding-modal-animation)