### PR TITLE
Clarify copy on talking-clock

### DIFF
--- a/app/assets/stories/talking_clock/talking_clock.json
+++ b/app/assets/stories/talking_clock/talking_clock.json
@@ -5,7 +5,7 @@
 				{
 					"location": "add-part-button",
 					"position": "top",
-					"text": "You're going to use code to connect a microphone, a speaker, and a clock."
+					"text": "You're going to use code to connect<br/>a microphone, a speaker, and a clock.<br/>Click on **ADD PARTS** and drag them in."
 				}
 			],
 			"validation": {


### PR DESCRIPTION
<img width="567" alt="screen shot 2016-12-07 at 15 27 47" src="https://cloud.githubusercontent.com/assets/169328/20973771/c2433fca-bc91-11e6-997c-146b5e8d7177.png">

Related to: https://trello.com/c/63f1maOH/937-talking-clock-challenge-needs-explicit-click-add-parts-copy-on-first-tooltip