### PR TITLE
Removing spacers between different types of toolbox categories

### DIFF
--- a/app/elements/kano-root-view/kano-root-view.html
+++ b/app/elements/kano-root-view/kano-root-view.html
@@ -257,8 +257,6 @@
             });
 
             toolbox = Object.keys(this.defaultCategories).map(id => this.defaultCategories[id]);
-            toolbox = toolbox
-                .concat({ type: 'separator' });
             // Generate the toolbox for the special mode
             if (this.mode.blocks && this.mode.blocks.length) {
                 let modeCat = {
@@ -275,7 +273,6 @@
                     };
                 });
                 toolbox.push(modeCat);
-                toolbox.push({ type: 'separator' });
             }
             toolbox = toolbox.concat(categories);
             this.set('toolbox', toolbox);


### PR DESCRIPTION

<img width="188" alt="screen shot 2016-12-07 at 16 46 44" src="https://cloud.githubusercontent.com/assets/169328/20977251/d9af736c-bc9c-11e6-9c3f-05833099d216.png">


Related to: https://trello.com/c/XxD6smN4/892-kano-code-difference-in-space-between-words-of-functions