### PR TITLE
Update slider to parse value as integer before returning

### DIFF
--- a/app/elements/part/kano-part-slider/kano-part-slider.html
+++ b/app/elements/part/kano-part-slider/kano-part-slider.html
@@ -36,13 +36,15 @@
             this.target = null;
         },
         getValue () {
-            return this.get('value');
+            let rawValue = this.get('value');
+            return parseInt(rawValue);
         },
         _valueChanged () {
+            let value = parseInt(this.value);
             if (this.target) {
-                this.target.node.set(this.target.property, this.value);
+                this.target.node.set(this.target.property, value);
             }
-            this.fire('update', this.value);
+            this.fire('update', value);
         }
     });
 </script>


### PR DESCRIPTION
HTML input range returns a String, so the slider part was also setting and returning a String. This updates the getValye and _valueChanged methods to parse the value as an integer before returning.

Fixes the following bug:
Slider part returns a string (should be a number)
https://trello.com/c/4urIiemz/925-slider-part-returns-a-string-should-be-a-number