### PR TITLE
[RC] Fix for passing the correct URL to Chromium

### DIFF
--- a/rpi/bin/make-apps
+++ b/rpi/bin/make-apps
@@ -126,7 +126,7 @@ URL = os.getenv('URL') or "https://make-apps-kit.kano.me"
 
 # TODO: for when Kano Code can handle the UI without a top bar
 # chromium-browser --kiosk URL
-cmdline=['chromium-browser',  '--app="{}"'.format(URL), '--start-maximized']
+cmdline = ['chromium-browser', '--app={}'.format(URL), '--start-maximized']
 UI_PROC = subprocess.Popen(cmdline)
 
 


### PR DESCRIPTION
Related to https://trello.com/c/eWqEtYNc/603-rc-clicking-on-kano-code-icon-opens-start-kano-me

The problem here was quoting the URL arg, which is not required when using `subprocess`. 

@paulvarache @tombettany @skarbat 