### PR TITLE
Add cross-storage, and save progress to Kano World

### DIFF
--- a/app/scripts/service/progress.js
+++ b/app/scripts/service/progress.js
@@ -1,9 +1,13 @@
+import crossStorage from 'cross-storage';
+
 let progressService = (sdk) => {
     let loadDebouncer = null,
         neverLoaded = true,
         progress = {};
 
-    const LOAD_DEBOUNCE_DELAY = 3000;
+    const storageLocation = Kano.MakeApps.config.WORLD_URL + '/cross-storage.html',
+        sharedStorage = new crossStorage.CrossStorageClient(storageLocation),
+        LOAD_DEBOUNCE_DELAY = 3000;
 
     localStorage.progress = localStorage.progress || JSON.stringify({});
 
@@ -136,7 +140,11 @@ let progressService = (sdk) => {
             return p;
         },
         saveToStorage () {
-            localStorage.progress = JSON.stringify(progress);
+            let storedProgress = JSON.stringify(progress);
+            localStorage.progress = storedProgress;
+            sharedStorage.onConnect().then(function () {
+                return sharedStorage.set('progress', storedProgress);
+            });
         },
         loadFromStorage () {
             try {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "browserify": "^13.0.1",
     "color": "^0.11.2",
     "connect-history-api-fallback": "^1.2.0",
+    "cross-storage": "^1.0.0",
     "cucumber": "^0.10.3",
     "del": "^2.2.0",
     "es6-object-assign": "^1.0.1",


### PR DESCRIPTION
As well as saving to localStorage for the apps domain, the progress service will save to Kano World's localStorage user the new cross-storage module