### PR TITLE
Update position of the tooltip to tell users that they have selected the wrong block

### DIFF
--- a/app/elements/behaviors/kano-blockly-validator-behavior.html
+++ b/app/elements/behaviors/kano-blockly-validator-behavior.html
@@ -72,9 +72,9 @@
                 }
             };
             step.tooltips = [{
-                position: 'left',
+                position: 'right',
                 text: Kano.MakeApps.CopyManager.get('wrong-block-added') + '<br>' + Kano.MakeApps.CopyManager.get('put-block-in-bin'),
-                location: 'blocks-panel'
+                location: 'blockly-bin'
             }];
             step.arrow = {
                 target: 'blockly-bin',


### PR DESCRIPTION
Trello card: https://trello.com/c/bNXpinmZ/1095-tooltip-that-tells-user-they-ve-grabbed-the-wrong-block-doesn-t-work-anymore