### PR TITLE
Add password reset and username request facilities on kano-auth component

### DIFF
--- a/app/elements/kano-auth/kano-auth.html
+++ b/app/elements/kano-auth/kano-auth.html
@@ -255,11 +255,11 @@
                         Please check your email and follow the instructions that have been sent to you.
                     </div>
                     <div class="body">
-                      Or <a on-tap="loginClicked">Log in <img src="/assets/icons/link-arrow.svg" class="link-arrow" /></a>
+                        Or <a on-tap="loginClicked">Log in <img src="/assets/icons/link-arrow.svg" class="link-arrow" /></a>
                     </div>
                     <div class="footer">
-                      Forgot your <a on-tap="displayPasswordReset">password</a> or
-                      <a on-tap="displayUsernameReminder">username</a>?<br />
+                        Forgot your <a on-tap="displayPasswordReset">password</a> or
+                        <a on-tap="displayUsernameReminder">username</a>?<br />
                         <a on-tap="signupClicked">Sign up <img src="/assets/icons/link-arrow.svg" class="link-arrow" /></a>
                     </div>
                 </div>


### PR DESCRIPTION
Email addresses are not unique to usernames, so users need to be able to request all usernames associated with their email addresses, and request password resets for user accounts individually. Simple forms on the `kano-auth` component make post requests to a new and updated route on the api to trigger password-rest and username-request emails.

Relies on this PR for the Kano Web API being merged in advance:
https://github.com/KanoComputing/kano-web-api/pull/370

Trello cards:
https://trello.com/c/iMFJqmQN/1194-2-forgot-username-button
https://trello.com/c/tEe13RUb/1193-5-password-reset-based-on-email-address-not-being-unique