### PR TITLE
Add delete sound, when blocks are disposed of on the toolbox

### DIFF
--- a/app/elements/kano-blockly/kano-blockly.html
+++ b/app/elements/kano-blockly/kano-blockly.html
@@ -519,6 +519,9 @@ Example:
                         Blockly.Events.enable();
                         // Delete the block without animation
                         block.dispose(true, false);
+                        // Compensate for the lack of audio
+                        // with the suppressed animation
+                        this.workspace.playAudio('delete');
                         this._onToolboxEndDrag();
                         return;
                     }


### PR DESCRIPTION
The Trello card below states that the challenge engine is not registering blocks dragged on to the toolbox as delete events, but this does seem to be the case – it just seems to be that the sound was not playing because the animation was suppressed.

Trello card: https://trello.com/c/a73ZYqTd/891-kano-code-dragging-block-to-left-deletes-part-but-doesn-t-play-delete-sound-and-challenge-engine-doesn-t-register-it-as-a-delete