### PR TITLE
Add extra check for api before running microphone _stop method

### DIFF
--- a/app/scripts/kano/app-modules/mic.html
+++ b/app/scripts/kano/app-modules/mic.html
@@ -36,7 +36,7 @@
             }
 
             _stop () {
-                if (this.api.microphone && typeof this.api.microphone.stopRecording === 'function') {
+                if (this.api && this.api.microphone && typeof this.api.microphone.stopRecording === 'function') {
                     this.api.microphone.stopRecording();
                 }
             }


### PR DESCRIPTION
Currently the onboarding flow is throwing an error when trying to call _stop on the microphone, since the api hasn't been initialised. This is a quick fix to falsify the conditional, rather than trying to find the microphone component on the API below. This should fix the bug in the Trello card below. @gpgabriel is hoping to refactor in future, but this should solve the problem for the moment.

Trello card: https://trello.com/c/xk0NbbQb/1674-kano-world-onboarding-no-sound-when-connecting-block-in-first-challenge