### PR TITLE
Update :host style of kano-workspace-camera to match kano-workspace-normal

### DIFF
--- a/app/elements/kano-workspace-camera/kano-workspace-camera.html
+++ b/app/elements/kano-workspace-camera/kano-workspace-camera.html
@@ -6,6 +6,8 @@
 <dom-module id="kano-workspace-camera">
     <style>
         :host {
+            background: var(--canvas-background, #ffffff);
+            border-radius: 5px;
             display: block;
             width: 100%;
             height: 100%;


### PR DESCRIPTION
This should fix the problem with the camera canvas not having any background, as in the bug in the Trello card below.

Trello card: https://trello.com/c/bs2x8J8T/1679-kano-code-prod-for-camera-before-you-take-a-picture-viewer-is-just-a-black-screen