### PR TITLE
Throw error when compression fails

### DIFF
--- a/tasks/build.js
+++ b/tasks/build.js
@@ -152,7 +152,10 @@ module.exports = (gulp, $) => {
                 removeComments: true
             })))
             .pipe($.if('*.js', $.uglify()))
-            .on('error', $.utils.notifyError)
+            .on('error', (e) => {
+                $.utils.notifyError(e);
+                throw e;
+            })
             .pipe(gulp.dest('www'));
     });
 


### PR DESCRIPTION
https://trello.com/c/Owo5qGPD/1745-2-jenkins-doesn-t-stop-the-build-when-a-step-fails