### PR TITLE
Extend play bundle with clienUtil

### DIFF
--- a/app/elements/play-bundle.html
+++ b/app/elements/play-bundle.html
@@ -1,5 +1,6 @@
 <!-- build:config -->
 <!-- endbuild-->
+<script src="../scripts/util/client.js"></script>
 <script src="../scripts/kano/make-apps/config.js"></script>
 <link rel="import" href="./kano-app-player/kano-app-player.html">
 <link rel="import" href="../scripts/kano/app-modules/index.html">


### PR DESCRIPTION
Fixing a bug with kano shares:
clientUtil global variable was missing from the bundle.
can't do the npm publish, but maybe @paulvarache please?