### PR TITLE
Kano-bitmap-list test updated

### DIFF
--- a/app/elements/kano-bitmap-list/test/index.html
+++ b/app/elements/kano-bitmap-list/test/index.html
@@ -84,6 +84,13 @@
                     list = fixture('addFrame');
                     list.bitmaps = createFrames(5);
                 });
+                test('addFrame selects the new frame', () => {
+                    let prevIndex = list.selectedIndex,
+                        newIndex;
+                    list.addFrame();
+                    newIndex = list.selectedIndex;
+                    assert(newIndex === prevIndex, 'When adding a frame, `selectedIndex` is not pointing to the newly created frame');
+                });
                 test('addFrame copies the previous frame', () => {
                     let prevFrame = list.selected.slice(0),
                         newFrame;


### PR DESCRIPTION
The selectedIndex should not increment when adding a new frame. Fix has been merged and the below test segment is therefore disposable.