### PR TITLE
Double quotes for background css property

### DIFF
--- a/app/scripts/kano/app-modules/app-modules.html
+++ b/app/scripts/kano/app-modules/app-modules.html
@@ -59,6 +59,8 @@
                 partsString = JSON.stringify(components);
 
                 template = template.join('\n');
+                //ensure 'background' css property will not carry double quotes
+                background = background ? background.replace(/"/ig, '\"') : null;
 
                 component = `
                     <dom-module id="kano-${componentName}">


### PR DESCRIPTION
The background property from json uses single quotes for the path, so we need to wrap that around with double quotes.