### PR TITLE
Change app priority for Spanish build

### DIFF
--- a/rpi/icons/locale/es_AR/make-apps.app
+++ b/rpi/icons/locale/es_AR/make-apps.app
@@ -5,7 +5,7 @@
     "tagline": "Aplicaciones autenticas con Bloques Kano", 
     "colour": "#34495E", 
     "desktop": false, 
-    "priority": 1000, 
+    "priority": -50, 
     "dependencies": [], 
     "overrides": [], 
     "packages": [


### PR DESCRIPTION
Assuming make apps is not translated for the workshop image. If it is, we can change this back.