### PR TITLE
Fix animation frame selection

### DIFF
--- a/app/elements/kano-bitmap-list/kano-bitmap-list.html
+++ b/app/elements/kano-bitmap-list/kano-bitmap-list.html
@@ -115,7 +115,8 @@
                 }
             },
             observers: [
-                '_selectedChanged(selected.*)'
+                '_selectedChanged(selected.*)',
+                '_bitmapsChanged(bitmaps)'
             ],
             _selectedChanged (e) {
                 let index = this.selectedIndex,
@@ -128,12 +129,17 @@
                     });
                 } else if (e.path === 'selected' && e.value) {
                     this.select(e.value);
-                } else {
+                } else if (e.path === 'selected') {
                     if (this.bitmaps.length === 0) {
                         this.set('bitmaps', [[]]);
                     }
                     this.selected = this.bitmaps[0].slice(0);
                 }
+            },
+            _bitmapsChanged () {
+                let lastIndex = this.bitmaps.length -1;
+                this.selectedIndex = lastIndex;
+                this.selected = this.bitmaps[lastIndex].slice(0);
             },
             _sortStarted (e) {
                 if (e.detail) {

--- a/app/elements/kano-bitmap-list/test/index.html
+++ b/app/elements/kano-bitmap-list/test/index.html
@@ -45,8 +45,8 @@
                     list = fixture('default');
                     list.bitmaps = createFrames(5);
                 });
-                test('`selected` is the first bitmap by default', () => {
-                    assert.deepEqual(list.selected, list.bitmaps[0], 'Selected is not the first bitmap by default');
+                test('`selected` is the last bitmap by default', () => {
+                    assert.deepEqual(list.selected, list.bitmaps[list.bitmaps.length - 1], 'Selected is not the last bitmap by default');
                 });
             });
 
@@ -89,7 +89,7 @@
                         newIndex;
                     list.addFrame();
                     newIndex = list.selectedIndex;
-                    assert(newIndex === prevIndex, 'When adding a frame, `selectedIndex` is not pointing to the newly created frame');
+                    assert(newIndex === prevIndex + 1, 'When adding a frame, `selectedIndex` is not pointing to the newly created frame');
                 });
                 test('addFrame copies the previous frame', () => {
                     let prevFrame = list.selected.slice(0),


### PR DESCRIPTION
The bitmapsChanged observer was unnecessarily triggered when creating a new frame - setting back the selectedIndex to 0. This PR proposes getting rid of that observer and migrate the check for empty bitmaps array to the selectedChanged observer. This way the selectedIndex can be set easily to the newly created frame.