### PR TITLE
Fix set-rectangle-color

### DIFF
--- a/app/scripts/kano/make-apps/parts/lightboard/light-rectangle.html
+++ b/app/scripts/kano/make-apps/parts/lightboard/light-rectangle.html
@@ -170,16 +170,18 @@
                 block: (part) => {
                     return {
                         id: 'set_color',
-                        message0: `${part.name} ${Blockly.Msg.BLOCK_LIGHT_CIRCLE_COLOR}`,
+                        message0: `${part.name} ${Blockly.Msg.BLOCK_LIGHT_CIRCLE_SET_COLOR}`,
                         args0: [{
                             type: "input_value",
                             name: "COLOR",
                             check: 'Colour'
                         }],
-
                         inputsInline: false,
                         previousStatement: null,
-                        nextStatement: null
+                        nextStatement: null,
+                        shadow: {
+                            'COLOR': '<shadow type="colour_picker"><field name="COLOUR">#ffffff</field></shadow>'
+                        }
                     };
                 },
                 javascript: (part) => {


### PR DESCRIPTION
Related to https://trello.com/c/eAAu5x7m
on a side note:
I have noticed that the localised message variable name has the name 'circle'.. This is how it is currently on the getter too, so I didn't change that here.. It's okay as the rendered string is 'set color'  anyway, but maybe in the future we can think about a clearer naming.