### PR TITLE
RPi: Add localisation for the RPi wrapper

### DIFF
--- a/debian/make-apps.install
+++ b/debian/make-apps.install
@@ -1,6 +1,5 @@
 rpi/bin/* /usr/bin
 rpi/make_apps /usr/lib/python2.7/dist-packages
-www/* /usr/share/make-apps
 
 rpi/icons/MakeApps.lnk usr/share/kano-desktop/kdesk/kdesktop/
 rpi/icons/make-apps.app usr/share/applications
@@ -8,3 +7,5 @@ rpi/icons/locale/es_AR/*.app /usr/share/applications/locale/es_AR/
 rpi/icons/make-apps.png usr/share/icons/Kano/88x88/apps
 rpi/icons/kano-code-kdesk-hover.png usr/share/icons/Kano/88x88/apps
 rpi/media /usr/share/make-apps/
+
+rpi/locale/* usr/share/locale/

--- a/debian/rules
+++ b/debian/rules
@@ -1,15 +1,10 @@
 #!/usr/bin/make -f
 
-export PATH := /usr/local/bin/:$(PATH)
 
 %:
 	dh $@
 
 override_dh_auto_build:
-	curl --silent --location https://deb.nodesource.com/setup_4.x | bash -
-	apt-get install --yes nodejs
-	npm install
-	node_modules/.bin/bower install --allow-root
-	NODE_ENV=production TARGET=rpi ./node_modules/.bin/gulp build
+	cd rpi/po && make build
 
 override_dh_auto_install override_dh_auto_test:

--- a/rpi/bin/make-apps
+++ b/rpi/bin/make-apps
@@ -23,6 +23,12 @@ if __name__ == '__main__' and __package__ is None:
 
     if not DIR_PATH.startswith('/usr'):
         sys.path.insert(1, DIR_PATH)
+        LOCALE_PATH = os.path.join(DIR_PATH, 'locale')
+    else:
+        LOCALE_PATH = None
+
+import kano_i18n.init
+kano_i18n.init.install('make-apps', LOCALE_PATH)
 
 from kano_profile.tracker import Tracker
 kanotracker = Tracker()
@@ -104,16 +110,38 @@ SERVER_PROC.start()
 
 
 if not is_internet():
-    msg = 'kano-dialog title="Oh No" description="You need to be connected to the Internet to launch Kano Code. Click on the OK button to set up your WiFi" button="OK,color:green,return_value:0" button="QUIT,color:red,return_value:1" no-taskbar'
+    msg = (
+        u'kano-dialog title="{title}" '
+        u'description="{desc}" '
+        u'button="{ok},color:green,return_value:0" '
+        u'button="{quit},color:red,return_value:1" '
+        u'no-taskbar'
+    ).format(
+        title=_(u'Oh No'),
+        desc=_(u'You need to be connected to the Internet to launch Kano Code. Click on the OK button to set up your WiFi'),
+        ok=_(u'OK').upper(),
+        quit=_(u'Quit').upper()
+    )
     ret, dummy1, dummy2 = run_cmd(msg)
+
     if "1" == ret.strip():
         sys.exit(0)
 
-    run_cmd('sudo kano-settings wifi')
+    run_cmd('sudo kano-settings wifi', localised=True)
 
     if not is_internet():
-        msg2 = 'kano-dialog title="Oh No" description="It looks like something went wrong. Your Kano kit is still not connected to the Internet. Unfortunately Kano Code can\'t be launched offline" button="QUIT,color:red,return_value:1" no-taskbar'
-        run_cmd(msg2)
+        msg = (
+            u'kano-dialog '
+            u'title="{title}" '
+            u'description="{desc}" '
+            u'button="{quit},color:red,return_value:1" '
+            u'no-taskbar'
+        ).format(
+            title=_(u'Oh No'),
+            desc=_(u"It looks like something went wrong. Your Kano kit is still not connected to the Internet. Unfortunately Kano Code can\'t be launched offline"),
+            quit=_(u'Quit').upper()
+        )
+        run_cmd(msg)
         sys.exit(0)
 
 

--- a/rpi/icons/locale/es_AR/make-apps.app
+++ b/rpi/icons/locale/es_AR/make-apps.app
@@ -1,19 +1,6 @@
 {
-    "launch_command": "make-apps", 
-    "description": "Haz aplicaciones autenticas y comp\u00e1rtelas con tus amigos y gente de todo el mundo. Domina data y explora las mec\u00e1nicas de juego con esta nueva herramienta de creaci\u00f3n.", 
-    "title": "Kano Code", 
-    "tagline": "Aplicaciones autenticas con Bloques Kano", 
-    "colour": "#34495E", 
-    "desktop": false, 
-    "priority": -50, 
-    "dependencies": [], 
-    "overrides": [], 
-    "packages": [
-        "make-apps"
-    ], 
-    "slug": "make-apps", 
-    "categories": [
-        "code"
-    ], 
-    "icon": "make-apps"
+    "description": "Haz aplicaciones aut\u00e9nticas y comp\u00e1rtelas con tus amigos y gente de todo el mundo. Domina data y explora las mec\u00e1nicas de juego con esta nueva herramienta de creaci\u00f3n.",
+    "title": "Kano Code",
+    "tagline": "Aplicaciones aut\u00e9nticas con Bloques Kano",
+    "priority": -50
 }

--- a/rpi/po/Makefile
+++ b/rpi/po/Makefile
@@ -1,0 +1,43 @@
+APPNAME=make-apps
+ORG="Kano Computing Ltd."
+
+MSGLANGS=$(notdir $(wildcard *po))
+MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
+
+.PHONY: clean_locales messages
+
+build: $(MSGOBJS)
+
+update: $(MSGLANGS)
+
+clean_locales:
+	rm -rf ../locale
+
+clean: clean_locales
+	rm -f messages.pot
+
+define generate-pypotfiles
+grep "env python" -rl --exclude=*.py --exclude-dir=po .. > PYPOTFILES
+find .. -not \( -path ../tests -prune \) -name *.py >> PYPOTFILES
+endef
+
+define run-xgettext
+xgettext -f PYPOTFILES -L Python --force-po -o messages.pot \
+    --keyword=N_ --package-name=$(APPNAME) --copyright-holder=$(ORG)
+endef
+
+messages:
+	$(generate-pypotfiles)
+	$(run-xgettext)
+
+messages.pot:
+	$(generate-pypotfiles)
+	$(run-xgettext)
+
+%.po: messages.pot
+	msgmerge -N -U $*.po messages.pot
+	touch $*.po
+
+../locale/%/LC_MESSAGES/$(APPNAME).mo: clean_locales
+	mkdir -p $(dir $@)
+	msgfmt -c -o $@ $*.po

--- a/rpi/po/es_AR.po
+++ b/rpi/po/es_AR.po
@@ -1,0 +1,45 @@
+# Spanish translations for make-apps package
+# Copyright (C) 2017 Kano Computing Ltd.
+# This file is distributed under the same license as the make-apps package.
+# Albert Casals <dev@kano.me>, 2017.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: make-apps\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-16 18:00+0000\n"
+"PO-Revision-Date: 2017-02-16 18:00+0000\n"
+"Last-Translator: Albert Casals <dev@kano.me>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: es_AR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../bin/make-apps:114 ../bin/make-apps:134
+msgid "Oh No"
+msgstr "Oh no"
+
+#: ../bin/make-apps:115
+msgid ""
+"You need to be connected to the Internet to launch Kano Code. Click on the "
+"OK button to set up your WiFi"
+msgstr "Necesitas estar conectado a Internet para arrancar Código Kano. Haz click en "
+"el botón Ok para ajustar tu WiFi"
+
+#: ../bin/make-apps:116
+msgid "OK"
+msgstr "Bien"
+
+#: ../bin/make-apps:117 ../bin/make-apps:136
+msgid "Quit"
+msgstr "Salir"
+
+#: ../bin/make-apps:135
+msgid ""
+"It looks like something went wrong. Your Kano kit is still not connected to "
+"the Internet. Unfortunately Kano Code can't be launched offline"
+msgstr "Parece que algo fue mal. Tu Kit Kano no está conectado a Internet todavía. "
+"Desafortunadamente, Código Kano no puede funcionar en modo desconexión"


### PR DESCRIPTION
Add localised strings for the internet check wrapper on the RPi. Also
add the `es_AR` translations for these strings and remove unnecessary
build steps for the offline version.

@paulvarache @skarbat to review.