### PR TITLE
Add authenticated flag when user has successfully been logged in

### DIFF
--- a/app/elements/kano-app/kano-app.html
+++ b/app/elements/kano-app/kano-app.html
@@ -128,7 +128,8 @@ Example:
                    api-url="{{apiUrl}}"
                    assets-path="/assets"
                    on-success="_authSuccess"
-                   on-cancel="_authCancelled"></kano-auth>
+                   on-cancel="_authCancelled"
+                   successful="[[authenticated]]"></kano-auth>
         <paper-toast id="toast" text="[[message.text]]" duration="[[message.duration]]">
             <button type="button" name="button" hidden$="[[!message.closeWithButton]]" on-tap="_closeToast">[[message.buttonText]]</button>
         </paper-toast>
@@ -155,6 +156,10 @@ Example:
             route: {
                 type: String,
                 observer: '_routeChanged'
+            },
+            authenticated: {
+                type: Boolean,
+                value: false
             }
         },
         listeners: {
@@ -298,6 +303,7 @@ Example:
             if (this._needsNotifications()) {
                 this._startNotificationsPolling();
             }
+            this.authenticated = true;
         },
         _populateUser () {
             this._updateProfile();


### PR DESCRIPTION
Add this to the `kano-auth` component as a property to control button visibity and progress.

Requires the following PR to be merged into the web-components repo, and the repo re-released: https://github.com/KanoComputing/web-components/pull/35

This should help to fix the following bug:
https://trello.com/c/Z7sfeWFv/54-kano-world-onboarding-creating-a-user-after-onboarding-does-not-log-him-in-automatically