### PR TITLE
Change add-parts strategy. Add animation when part added

### DIFF
--- a/app/elements/kano-add-parts/kano-add-parts.html
+++ b/app/elements/kano-add-parts/kano-add-parts.html
@@ -83,7 +83,7 @@
         <header>
             <div class="label">[[localize('ADD_PARTS', 'Add Parts')]]</div>
             <button type="button" class="button" on-tap="_cancel">[[localize('CANCEL', 'Cancel')]]</button>
-            <button type="button" class="button add" on-tap="_confirm">[[localize('DONE', 'Done')]]</button>
+            <button type="button" class="button add" on-tap="_confirm" hidden>[[localize('DONE', 'Done')]]</button>
         </header>
         <div class="categories">
             <div class="ui">
@@ -102,10 +102,7 @@
                 <template is="dom-repeat" items="[[availableParts]]" filter="[[_getFilter('data')]]" as="part">
                     <kano-add-parts-item label="[[part.label]]"
                                             type="[[part.type]]"
-                                            count="[[_getSelectedNumber(part.type, selection.*)]]"
-                                            selected$="[[_isInSelection(part.type, selection.*)]]"
-                                            on-part-tap="_addPart"
-                                            on-bin-tap="_removePart"></kano-add-parts-item>
+                                            on-part-tap="_addPart"></kano-add-parts-item>
                 </template>
             </div>
             <div class="hardware">
@@ -113,10 +110,7 @@
                 <template is="dom-repeat" items="[[availableParts]]" filter="[[_getFilter('hardware')]]" as="part">
                     <kano-add-parts-item label="[[part.label]]"
                                             type="[[part.type]]"
-                                            count="[[_getSelectedNumber(part.type, selection.*)]]"
-                                            selected$="[[_isInSelection(part.type, selection.*)]]"
-                                            on-part-tap="_addPart"
-                                            on-bin-tap="_removePart"></kano-add-parts-item>
+                                            on-part-tap="_addPart"></kano-add-parts-item>
                 </template>
             </div>
         </div>
@@ -142,6 +136,7 @@
                     this.set(`selection.${type}`, 0);
                 }
                 this.set(`selection.${type}`, Math.min(5, this.selection[type] + 1));
+                this._confirm();
             },
             _removePart (e) {
                 let type = e.detail;            

--- a/app/elements/kano-editor-lightboard/kano-editor-lightboard.html
+++ b/app/elements/kano-editor-lightboard/kano-editor-lightboard.html
@@ -157,10 +157,9 @@
             border: 0px;
             cursor: pointer;
         }
-        ::slotted(kano-part-microphone),
-        ::slotted(kano-part-oscillator),
-        ::slotted(kano-part-clock),
-        ::slotted(kano-part-speaker) {
+        ::slotted(.data),
+        ::slotted(.hardware),
+        ::slotted(kano-part-oscillator) {
             display: none;
         }
     </style>
@@ -181,16 +180,16 @@
                                     on-fullscreen-button-clicked="_toggleFullscreen"
                                     on-reset-button-clicked="_resetAppState"></kano-workspace-toolbar>
             <div class="add-parts">
-                <div class="label">Parts</div>
+                <div class="label">[[localize('PARTS', 'Parts')]]</div>
                 <div class="action">
                     <label for="add-part-button">[[localize('ADD_PART', 'Add Part')]]</label>
-                    <button type="button" on-tap="_addPartsTapped">+</button>
+                    <button id="add-part-button" type="button" on-tap="_addPartsTapped">+</button>
                 </div>
             </div>
             <div class="part-list">
                 <sortable-js handle=".handle" animation="150">
-                    <template is="dom-repeat" items="{{parts}}" as="part">
-                        <div class="part">
+                    <template is="dom-repeat" items="{{parts}}" as="part" on-dom-change="_partsElementsRepeaterChanged">
+                        <div class="part" id$="part-[[part.id]]">
                             <iron-icon class="handle" icon="menu"></iron-icon>
                             <kano-part-list-item model="[[part]]" on-tap="_partItemTapped"></kano-part-list-item>
                             <button type="button" class="remove-part" on-tap="_removePart">
@@ -239,18 +238,70 @@
                     notify: true
                 }
             },
+            observers: [
+                '_partsAddedOrRemoved(parts.splices)'
+            ],
             ready () {
                 // Temporary. Duplicate of code in `kano-view-editor` will be removed
                 // when this add-parts modal is moved to the `kano-app-editor` component
                 this.availableParts = Kano.MakeApps.Parts.list.filter((part) => {
                     return Kano.MakeApps.Mode.modes.lightboard.parts.indexOf(part.type) !== -1;
                 });
+                this._partsToAnimateIn = [];
             },
             attached () {
                 this.makeButtonIconPaths = {
                     stopped: 'M 4,18 10.5,14 10.5,6 4,2 z M 10.5,14 17,10 17,10 10.5,6 z',
                     running: 'M 2,18 6,18 6,2 2,2 z M 11,18 15,18 15,2 11,2 z'
                 };
+            },
+            _partsAddedOrRemoved (changeRecord) {
+                if (changeRecord && changeRecord.keySplices) {
+                    changeRecord.keySplices.forEach(splice => {
+                        let added = splice.added;
+                        added.forEach(key => {
+                            let part = this.get(`parts.${key}`),
+                                partEl;
+                            if (!part) {
+                                return;
+                            }
+                            partEl = this.$$(`#part-${part.id}`);
+                            this._partsToAnimateIn.push(part);
+                        });
+                    });
+                }
+            },
+            _partsElementsRepeaterChanged () {
+                this._partsToAnimateIn.forEach(part => {
+                    let partEl = this.$$(`#part-${part.id}`),
+                        listItemEl,
+                        partInlineControlsEl;
+                    if (!partEl) {
+                        return;
+                    }
+                    listItemEl = partEl.querySelector('kano-part-list-item');
+                    partInlineControlsEl = listItemEl.getInlineControlsElement();
+                    partEl.animate({
+                        transform: ['translateX(30%)', 'translateX(0%)'],
+                        opacity: [0, 1]
+                    }, {
+                        duration: 500,
+                        easing: 'ease-out',
+                        delay: 300,
+                        fill: 'backwards'
+                    });
+                    if (partInlineControlsEl) {
+                        partInlineControlsEl.animate({
+                            opacity: [0, 1]
+                        }, {
+                            duration: 600,
+                            delay: 800,
+                            fill: 'backwards',
+                            easing: 'ease-out'
+                        });
+                    }
+                });
+                this._partsToAnimateIn = [];
             },
             _resetAppState () {
                 this.fire('reset-app-state');

--- a/app/elements/kano-part-list-item/kano-part-list-item.html
+++ b/app/elements/kano-part-list-item/kano-part-list-item.html
@@ -28,13 +28,13 @@
         <div class="label">[[model.name]]</div>
         <div class="controls" id="controls"></div>
         <template id="oscillator">
-            <kano-ic-oscillator model="[[model]]"></kano-ic-oscillator>
+            <kano-ic-oscillator id="inline-controls" model="[[model]]"></kano-ic-oscillator>
         </template>
         <template id="microphone">
-            <kano-ic-microphone model="[[model]]"></kano-ic-microphone>
+            <kano-ic-microphone id="inline-controls" model="[[model]]"></kano-ic-microphone>
         </template>
         <template id="clock">
-            <kano-ic-clock model="[[model]]"></kano-ic-clock>
+            <kano-ic-clock id="inline-controls" model="[[model]]"></kano-ic-clock>
         </template>
     </template>
     <script>
@@ -73,6 +73,12 @@
                 }
 
                 this.$.controls.appendChild(this.instance.root);
+            },
+            getInlineControlsElement () {
+                if (this.instance) {
+                    return this.$$('#inline-controls');
+                }
+                return null;
             }
         });
     </script>

--- a/app/elements/kano-workspace/kano-workspace.html
+++ b/app/elements/kano-workspace/kano-workspace.html
@@ -438,6 +438,7 @@
             tagName = model.tagName;
             element = document.createElement(tagName);
             element.setAttribute('id', model.id);
+            element.classList.add(model.partType);
             element.addEventListener('model-changed', (e) => {
                 let detail = e.detail,
                     path;

--- a/app/scripts/kano/make-apps/msg/en.js
+++ b/app/scripts/kano/make-apps/msg/en.js
@@ -56,6 +56,8 @@
     Kano.MakeApps.Msg.IMPORT = "Import";
     Kano.MakeApps.Msg.GIVE_FEEDBACK = "Give Feedback";
 
+    Kano.MakeApps.Msg.PARTS = "Parts";
+
     Kano.MakeApps.Msg.STROKE_SIZE = "Stroke Size";
     Kano.MakeApps.Msg.STROKE_COLOR = "Stroke Color";
     Kano.MakeApps.Msg.WIDTH = "Width";


### PR DESCRIPTION
Related to https://trello.com/c/xYNeEH4H/91-parts-menu-refinefement,
https://trello.com/c/95tOX6TX/89-0-5-stop-non-ui-parts-showing-on-the-canvas-lightboard