### PR TITLE
topbar: The exit button becomes back when running on Electron

### DIFF
--- a/app/elements/kano-editor-topbar/kano-editor-topbar.html
+++ b/app/elements/kano-editor-topbar/kano-editor-topbar.html
@@ -12,7 +12,7 @@
                 background: #394148;
                 color: rgba(255, 255, 255, 0.5);
                 height: 32px;
-                padding: 0px 4px;
+                padding: 0px 4px 0px 0px;
                 border-bottom: 1px solid #282E34;
             }
             .title {
@@ -110,15 +110,20 @@
             .back {
                 --iron-icon-width: 16px;
                 --iron-icon-height: 16px;
-                margin-right: 8px;
+                padding-right: 8px;
+                padding-left: 4px;
+                cursor: pointer;
+            }
+            a.back:hover {
+                background-color: rgba(255, 255, 255, 0.1);
             }
             [hidden] {
                 display: none !important;
             }
         </style>
-        <a href$="[[exitUrl]]" class="back">
+        <a class="back" on-tap="_exitButtonTapped">
             <iron-icon class="back" src="/assets/icons/back.svg"></iron-icon>
-            <span>[[localize('EXIT', 'Exit')]]</span>
+            <span>[[exitButtonLabel]]</span>
         </a>
         <iron-image class="title" src="/assets/kano-logo-simple.svg" sizing="contain"></iron-image>
         <div class="user-profile" id="profile-container">
@@ -147,7 +152,7 @@
     </template>
     <script>
         Polymer({
-            is:'kano-editor-topbar',
+            is: 'kano-editor-topbar',
             behaviors: [Kano.Behaviors.I18nBehavior],
             properties: {
                 exitUrl: String,
@@ -155,7 +160,22 @@
                     type: Object,
                     value: null
                 },
+                exitButtonLabel: String,
                 profile: Object
+            },
+            attached () {
+                this.exitButtonLabel = this._runningOnElectron() ? this.localize('BACK', 'Back') : this.localize('EXIT', 'Exit');
+            },
+            _runningOnElectron () {
+                return navigator.userAgent.indexOf("Electron") > -1;
+            },
+            _exitButtonTapped () {
+                if (this._runningOnElectron()) {
+                    window.history.back();
+                    return;
+                }
+
+                window.location = this.exitUrl;
             },
             _closeTooltip () {
                 this.$.tooltip.close();


### PR DESCRIPTION
Turn the EXIT button into BACK when running in the electron app. Also made some minor styling changes and added mouse hover.