### PR TITLE
Boolean if part-editor positioned over code-editor or window

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.html
+++ b/app/elements/kano-app-editor/kano-app-editor.html
@@ -222,13 +222,9 @@ Example:
         position: relative;
     }
     #edit-part-dialog {
-        @apply --layout-vertical;
         overflow: auto;
     }
-    #edit-part-dialog kano-part-editor {
-        flex: 1 0 auto;
-        min-width: 420px;
-    }
+
     #edit-part-dialog .icon-button {
         position: absolute;
         right: 0;
@@ -374,7 +370,7 @@ Example:
                 </div>
             </iron-pages>
         </paper-dialog>
-        <paper-dialog id="edit-part-dialog" fit-into="[[codeEditor]]" entry-animation="from-big-animation" on-iron-overlay-closed="_partEditorDialogClosed">
+        <paper-dialog id="edit-part-dialog" entry-animation="from-big-animation" on-iron-overlay-closed="_partEditorDialogClosed">
             <button class="icon-button" type="button" dialog-dismiss>
                 <iron-icon icon="close"></iron-icon>
             </button>

--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -404,9 +404,15 @@ Polymer({
         this.$.partsPanel.closeDrawer();
     },
     selectedChanged (newValue) {
-        // The selection is cleared
         if (!newValue) {
             this.drawerPage = 'background-editor';
+            return;
+        }
+
+        if (newValue.fullscreenEdit) {
+            this.$['edit-part-dialog'].fitInto = window;
+        } else {
+            this.$['edit-part-dialog'].fitInto = this.$['root-view'];
         }
     },
     panelStateChanged () {
@@ -561,8 +567,6 @@ Polymer({
     },
     attached () {
         this.target = document.body;
-        this.codeEditor = this.$['root-view'];
-
         this.partEditorOpened = false;
         this.backgroundEditorOpened = false;
 

--- a/app/elements/kano-part-editor/kano-part-editor.html
+++ b/app/elements/kano-part-editor/kano-part-editor.html
@@ -10,9 +10,10 @@
         display: flex;
         flex-direction: column;
         position: relative;
-        min-width: 85%;
         text-align: center;
         border-radius: 6px;
+        min-width: 420px;
+        background-color: #fff;
     }
     :host(.is-scrolled) #config-panel-container::before {
         content: '';

--- a/app/scripts/kano/make-apps/parts/lightboard/light-animation.html
+++ b/app/scripts/kano/make-apps/parts/lightboard/light-animation.html
@@ -14,6 +14,7 @@
             rotationDisabled: true,
             scaleDisabled: true,
             configPanel: 'kano-light-animation-editor',
+            fullscreenEdit: true,
             customizable: {
                 properties: [{
                     key: 'width',

--- a/app/scripts/kano/make-apps/parts/part.html
+++ b/app/scripts/kano/make-apps/parts/part.html
@@ -49,6 +49,7 @@
                 this.userProperties = Object.assign({}, opts.userProperties);
                 this.nonvolatileProperties = Array.isArray(opts.nonvolatileProperties) ? opts.nonvolatileProperties : [];
                 this.removable = typeof opts.removable === 'undefined' ? true : opts.removable;
+                this.fullscreenEdit = opts.fullscreenEdit || false;
             }
             getUniqueName (value, inc=0) {
                 let newName = inc ? `${value} ${inc}` : value;


### PR DESCRIPTION
Before starting on restyling the light animation editor, I wanted to simplify how we can use a full-screen modal for the part-editor. With these changes here the modal can be centered relative to the window and not the blockly space if needed.