### PR TITLE
Move the default block in the lightboard mode more into the middle

### DIFF
--- a/app/scripts/kano/make-apps/mode/mode.html
+++ b/app/scripts/kano/make-apps/mode/mode.html
@@ -80,7 +80,7 @@
                 padding: 10,
                 color: '#263238'
             },
-            defaultBlocks: `<xml xmlns="http://www.w3.org/1999/xhtml"><block type="part_event" id="default_part_event_id" colour="#33a7ff" x="150" y="40"><field name="EVENT">global.start</field></block></xml>`,
+            defaultBlocks: `<xml xmlns="http://www.w3.org/1999/xhtml"><block type="part_event" id="default_part_event_id" colour="#33a7ff" x="290" y="120"><field name="EVENT">global.start</field></block></xml>`,
             events: [{
                 label: 'UP pressed',
                 id: 'lightboard-js-up'


### PR DESCRIPTION
<img width="920" alt="screen shot 2017-03-28 at 12 19 34" src="https://cloud.githubusercontent.com/assets/169328/24402509/d32a5bcc-13b0-11e7-9653-3bba544430f5.png">

Related to: https://trello.com/c/f6MOMy63/182-move-default-block-in-ide-off-left-hand-edge