### PR TITLE
Add number to math category

### DIFF
--- a/app/scripts/kano/make-apps/blockly/math.js
+++ b/app/scripts/kano/make-apps/blockly/math.js
@@ -395,6 +395,7 @@
         id: 'math',
         colour: COLOUR,
         blocks: [
+            'math_number',
             'math_arithmetic',
             {
                 id: 'unary',


### PR DESCRIPTION
Related to https://trello.com/c/z0eN9dkO/228-0-5-add-number-block-to-math-category-duplicate-from-var