### PR TITLE
Add better UI elements tracking in challenges

### DIFF
--- a/app/elements/kano-app-challenge/kano-challenge-ui.html
+++ b/app/elements/kano-app-challenge/kano-challenge-ui.html
@@ -290,16 +290,28 @@ Example:
             this.modal = this.$.modal;
             this.highlight = {};
             this.loadSound('/assets/audio/sounds/ding.mp3');
+            this._refitUiElements = this._refitUiElements.bind(this);
+            this.eventsCausingRefit = {
+                'toolbox-scroll': ['flyout_block'],
+                'workspace-scroll': ['block'],
+                'block-move': ['block']
+            };
         },
         attached () {
             this.editor = Polymer.dom(this.$.content).getDistributedNodes()[0];
             this.updateTooltips = this.updateTooltips.bind(this);
             this.addEventListener('mousewheel', this.updateTooltips, true);
             window.addEventListener('resize', this.updateTooltips);
+            Object.keys(this.eventsCausingRefit).forEach(eventName => {
+                this.addEventListener(eventName, this._refitUiElements);
+            });
         },
         detached () {
             this.removeEventListener('mousewheel', this.updateTooltips);
             window.removeEventListener('resize', this.updateTooltips);
+            Object.keys(this.eventsCausingRefit).forEach(eventName => {
+                this.removeEventListener(eventName, this._refitUiElements);
+            });
         },
         getToolbox () {
             return this.editor.getBlocklyWorkspace().toolbox;
@@ -307,26 +319,60 @@ Example:
         _nextStep () {
             this.fire('next-step');
         },
+        /**
+         * Reposition the UI elements of the current step without delay.
+         * Useful when a user interaction changed the position of one of the targets.
+         */
+        _refitUiElements (e) {
+            let step = this.step,
+                targetConcerned = this.eventsCausingRefit[e.type];
+            if (step.beacon && this._targetIsConcerned(step.beacon.target, targetConcerned)) {
+                this._fitBeacon(step);
+            }
+            if (step.arrow && this._targetIsConcerned(step.arrow.target, targetConcerned)) {
+                this._fitArrow(step);
+            }
+            this._fitTooltips(step);
+        },
+        /**
+         * Checks if the target of the beacon matches the type of targets concerned by the refit event received
+         */
+        _targetIsConcerned (target, targetTypes) {
+            return typeof target === 'object' && Object.keys(target).some(key => targetTypes.indexOf(key) !== -1);
+        },
         computeTooltips (step) {
             this.set('tooltips', []);
             this.debounce('computeTooltips', () => {
-                /* With hints disabled, only show tooltips for injected steps */
-                if (!this.state.hints.enabled && !step.injected) {
-                    this.tooltips = [];
-                    return;
-                }
-
-                let tooltips = step.tooltips || [];
-                tooltips = tooltips.map((tooltip) => {
-                    let copy = Object.assign({}, tooltip);
-                    copy.target = this._getTargetElement(tooltip.location);
-                    copy.text = tooltip.text;
-                    copy.tracking = tooltip.tracking !== false ? true : false;
-                    return copy;
-                });
-
-                this.set('tooltips', tooltips);
+                this._fitTooltips(step, true);
             }, 200);
+        },
+        _fitTooltips (step, scroll) {
+            /* With hints disabled, only show tooltips for injected steps */
+            if (!this.state.hints.enabled && !step.injected) {
+                this.tooltips = [];
+                return;
+            }
+
+            let tooltips = step.tooltips || [];
+            tooltips = tooltips.map(tooltip => {
+                let copy = Object.assign({}, tooltip);
+                copy.target = this._getTargetElement(tooltip.location);
+                if ('getBoundingClientRect' in copy.target) {
+                    copy.target = copy.target.getBoundingClientRect();
+                }
+                if (scroll) {
+                    this._scrollWorkspaceOnTargetIfNeeded(copy.target, tooltip.location);
+                }
+                copy.text = tooltip.text;
+                copy.tracking = !!tooltip.tracking;
+
+                return copy;
+            });
+            // Forces a recompute on the dom-repeat to make sure all tooltips are updated
+            this.set('tooltips', []);
+            this.async(() => {
+                this.set('tooltips', tooltips);
+            });
         },
         _tooltipDomChanged (e) {
             let tooltips = Polymer.dom(this.root).querySelectorAll('kano-tooltip[bounce]'),
@@ -358,35 +404,39 @@ Example:
             }
         },
         computeArrow (step) {
-            let source, target;
-
             if (!step || !step.arrow || (!this.state.hints.enabled && !step.injected)) {
                 this.$.arrow.hide();
                 this.arrow = {};
                 return;
             }
             this.async(() => {
-                if (step.arrow.source) {
-                    source = this._getTargetElement(step.arrow.source);
-                    if ('getBoundingClientRect' in source) {
-                        source = source.getBoundingClientRect();
-                    }
-                }
-                target = this._getTargetElement(step.arrow.target);
-                if ('getBoundingClientRect' in target) {
-                    target = target.getBoundingClientRect();
-                }
-                this.set('arrow', {
-                    source,
-                    target,
-                    size: step.arrow.size || 70,
-                    angle: step.arrow.angle || 0
-                });
+                this._fitArrow(step, true);
             }, 300);
         },
-        computeBeacon (step) {
-            let target, angle, offset;
+        _fitArrow (step, scroll) {
+            let source, target;
 
+            if (step.arrow.source) {
+                source = this._getTargetElement(step.arrow.source);
+                if ('getBoundingClientRect' in source) {
+                    source = source.getBoundingClientRect();
+                }
+            }
+            target = this._getTargetElement(step.arrow.target);
+            if ('getBoundingClientRect' in target) {
+                target = target.getBoundingClientRect();
+            }
+            if (scroll) {
+                this._scrollWorkspaceOnTargetIfNeeded(target, step.arrow.target);
+            }
+            this.set('arrow', {
+                source,
+                target,
+                size: step.arrow.size || 70,
+                angle: step.arrow.angle || 0
+            });
+        },
+        computeBeacon (step) {
             this.$.beacon.animate({
                 opacity: [1, 0]
             }, {
@@ -404,27 +454,58 @@ Example:
             }
 
             this.async(() => {
-                target = this._getTargetElement(step.beacon.target);
-                angle = step.beacon.angle || 0;
-                offset = step.beacon.offset || 10;
-                if (target && ('getBoundingClientRect' in target)) {
-                    target = target.getBoundingClientRect();
-                }
-                this.set('beacon', {
-                    target,
-                    angle,
-                    offset
-                });
-                this.$.beacon.animate({
-                    opacity: [0, 1]
-                }, {
-                    duration: 200,
-                    delay: 10,
-                    fill: 'forwards'
-                });
-                this.toggleClass('animate', true, this.$.beacon);
-                this.toggleClass('animate', true, this.$.ring);
+                this._fitBeacon(step, true);
             }, 300);
+        },
+        _scrollWorkspaceOnTargetIfNeeded (target, location) {
+            if (location.block) {
+                let workspace = this.editor.getBlocklyWorkspace(),
+                    workspaceRect = workspace.svgBackground_.getBoundingClientRect(),
+                    viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
+                    viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
+                    block;
+                if (target &&
+                        (target.top + target.height > workspaceRect.top + workspaceRect.height) ||
+                        (target.left + target.width > workspaceRect.left + workspaceRect.width)) {
+                    block = this.getTargetBlock(location.block);
+                    workspace.scrollBlockIntoView(block, true);
+                }
+            }
+        },
+        _fitBeacon (step, scroll) {
+            let target = this._getTargetElement(step.beacon.target),
+                angle = step.beacon.angle || 0,
+                offset = step.beacon.offset || 10,
+                viewportWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
+                viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+            if (target && ('getBoundingClientRect' in target)) {
+                target = target.getBoundingClientRect();
+            }
+            if (scroll) {
+                this._scrollWorkspaceOnTargetIfNeeded(target, step.beacon.target);
+            }
+            // Check if the target is out of the viewport (vertically)
+            if (target && target.top + target.height > viewportHeight) {
+                if (step.beacon.target.flyout_block) {
+                    let toolbox = this._getElement('blockly-toolbox');
+                    // Force a scroll of the toolbox to move the target in the viewport. Add 50 to make sure it's not just at the border of the screen
+                    toolbox.scrollTop = toolbox.scrollTop + (target.top + target.height - viewportHeight) + 50;
+                }
+            }
+            this.set('beacon', {
+                target,
+                angle,
+                offset
+            });
+            this.$.beacon.animate({
+                opacity: [0, 1]
+            }, {
+                duration: 200,
+                delay: 10,
+                fill: 'forwards'
+            });
+            this.toggleClass('animate', true, this.$.beacon);
+            this.toggleClass('animate', true, this.$.ring);
         },
         _ringAnimationIterated (e) {
             this._ringSoundTimeout = setTimeout(() => {

--- a/app/elements/kano-blockly/blockly-override.js
+++ b/app/elements/kano-blockly/blockly-override.js
@@ -287,10 +287,6 @@ Blockly.Block.prototype.setColour = function(colour) {
     }
 };
 
-Blockly.Events.DROP_BLOCK = 'drop-block';
-Blockly.Events.OPEN_FLYOUT = 'open-flyout';
-Blockly.Events.CLOSE_FLYOUT = 'close-flyout';
-
 /**
  * Overrides Blockly color computation to use HEX colors instead of
  * fixed saturation and value

--- a/app/elements/kano-blockly/import.html
+++ b/app/elements/kano-blockly/import.html
@@ -19,3 +19,6 @@
 </script>
 <script src="./blockly-override.js"></script>
 <script src="./patch/core/block_render_svg.js"></script>
+<script src="./patch/core/workspace_svg.js"></script>
+<script src="./patch/core/events.js"></script>
+<script src="./patch/core/scrollbar.js"></script>

--- a/app/elements/kano-blockly/kano-blockly.html
+++ b/app/elements/kano-blockly/kano-blockly.html
@@ -67,6 +67,10 @@ Example:
             @apply(--layout-center);
         }
 
+        .blocklyBlockCanvas.smoothScroll, ::slotted(*.blocklyBlockCanvas.smoothScroll) {
+            transition: transform 200ms ease-out;
+        }
+
         .blocklyTreeRoot>div[role="group"]>div:not([role="treeitem"]), ::slotted(* .blocklyTreeRoot>div[role="group"]>div:not([role="treeitem"])) {
             display: none;
         }
@@ -277,6 +281,9 @@ Example:
                 type: Boolean,
                 value: false
             }
+        },
+        listeners: {
+            'toolbox.scroll': '_onToolboxScroll'
         },
         ready () {
             this.codeRelatedEvents = [Blockly.Events.CREATE, Blockly.Events.MOVE, Blockly.Events.CHANGE];
@@ -536,7 +543,12 @@ Example:
         onBlocklyChange (e) {
             if (e.type === Blockly.Events.OPEN_SEARCHBOX) {
                 this._openOmnibox();
-
+                return;
+            }
+            if (e.type === Blockly.Events.SCROLL) {
+                this.debounce('workspacePan', () => {
+                    this.fire('workspace-scroll');
+                }, 200);
                 return;
             }
             if (e.type === Blockly.Events.CREATE) {
@@ -556,6 +568,9 @@ Example:
                     this.workspace.fireChangeListener(ev);
                     this.lastCreated = null;
                     this._onToolboxEndDrag();
+                } else if (e.type === Blockly.Events.MOVE) {
+                    // The event type is `move` and the block concerned was not just created
+                    this.fire('block-move');
                 }
             }
             this.fire('change', e);
@@ -630,6 +645,11 @@ Example:
         },
         getToolbox () {
             return this.$.toolbox;
+        },
+        _onToolboxScroll (e) {
+            this.debounce('scrollEvent', () => {
+                this.fire('toolbox-scroll');
+            }, 200);
         }
     });
 </script>

--- a/app/elements/kano-blockly/patch/core/events.js
+++ b/app/elements/kano-blockly/patch/core/events.js
@@ -1,0 +1,28 @@
+/**
+ * Name of event that records a UI change.
+ * @const
+ */
+Blockly.Events.SCROLL = 'scroll';
+
+Blockly.Events.DROP_BLOCK = 'drop-block';
+Blockly.Events.OPEN_FLYOUT = 'open-flyout';
+Blockly.Events.CLOSE_FLYOUT = 'close-flyout';
+
+/**
+ * Class for a Scroll event.
+ * @param {Blockly.Workspace} workspace The affected block.
+ * @extends {Blockly.Events.Abstract}
+ * @constructor
+ */
+Blockly.Events.Scroll = function(workspace) {
+  Blockly.Events.Scroll.superClass_.constructor.call(this);
+  this.workspaceId = workspace.id;
+  this.recordUndo = false;
+};
+goog.inherits(Blockly.Events.Scroll, Blockly.Events.Abstract);
+
+/**
+ * Type of this event.
+ * @type {string}
+ */
+Blockly.Events.Scroll.prototype.type = Blockly.Events.SCROLL;

--- a/app/elements/kano-blockly/patch/core/scrollbar.js
+++ b/app/elements/kano-blockly/patch/core/scrollbar.js
@@ -1,0 +1,28 @@
+/**
+ * Set the sliders of both scrollbars to be at a certain position.
+ * @param {number} x Horizontal scroll value.
+ * @param {number} y Vertical scroll value.
+ */
+Blockly.ScrollbarPair.prototype.set = function(x, y) {
+  // This function is equivalent to:
+  //   this.hScroll.set(x);
+  //   this.vScroll.set(y);
+  // However, that calls setMetrics twice which causes a chain of
+  // getAttribute->setAttribute->getAttribute resulting in an extra layout pass.
+  // Combining them speeds up rendering.
+  var xyRatio = {};
+
+  var hHandlePosition = x * this.hScroll.ratio_;
+  var vHandlePosition = y * this.vScroll.ratio_;
+
+  var hBarLength = this.hScroll.scrollViewSize_;
+  var vBarLength = this.vScroll.scrollViewSize_;
+
+  xyRatio.x = this.getRatio_(hHandlePosition, hBarLength);
+  xyRatio.y = this.getRatio_(vHandlePosition, vBarLength);
+  this.workspace_.setMetrics(xyRatio);
+
+  this.hScroll.setHandlePosition(hHandlePosition);
+  this.vScroll.setHandlePosition(vHandlePosition);
+  Blockly.Events.fire(new Blockly.Events.Scroll(this.workspace_));
+};

--- a/app/elements/kano-blockly/patch/core/workspace_svg.js
+++ b/app/elements/kano-blockly/patch/core/workspace_svg.js
@@ -1,0 +1,16 @@
+Blockly.WorkspaceSvg.prototype.scrollBlockIntoView = function (block, animate) {
+    block.select();      // *block* is the block to scroll into view.
+    var xy = block.getRelativeToSurfaceXY();
+    var metrics = this.getMetrics();
+    var transitionCallback;
+    if (animate) {
+        transitionCallback = function () {
+            this.svgBlockCanvas_.removeEventListener('transitionend', transitionCallback);
+            Blockly.utils.removeClass(this.svgBlockCanvas_, 'smoothScroll');
+        }.bind(this);
+        Blockly.utils.addClass(this.svgBlockCanvas_, 'smoothScroll');
+        this.svgBlockCanvas_.addEventListener('transitionend', transitionCallback);
+    }
+    this.scrollbar.set(xy.x * this.scale - metrics.contentLeft - metrics.viewWidth  * 0.2,
+                        xy.y * this.scale - metrics.contentTop  - metrics.viewHeight * 0.3);
+};


### PR DESCRIPTION
Related to https://trello.com/c/lTEKd7Bm/233-3-update-beacon-position-after-workspace-has-been-panned-blocks-have-been-dragged-or-a-toolbox-panel-has-been-opened-toolbox-scr and https://trello.com/c/SvtUrVGF/210-3-auto-scroll-blocks-toolbox-or-auto-pan-workspace-where-a-beacon-would-otherwise-appear-off-screen