### PR TITLE
Change code/workspace screen proportions

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.html
+++ b/app/elements/kano-app-editor/kano-app-editor.html
@@ -36,9 +36,9 @@ Example:
 <dom-module id="kano-app-editor">
     <style>
     :host {
-        position: relative;
-        display: block;
         @apply --layout-vertical;
+        position: relative;
+        max-width: 100vw;
     }
     :host([lockdown]) {
         pointer-events: none;
@@ -53,17 +53,17 @@ Example:
     }
     :host section #blocks-panel {
         position: relative;
-        min-width: 38%;
-        max-width: 62%;
-        width: 55%;
-        @apply --layout-flex;
+        min-width: 50%;
+        max-width: 70%;
+        @apply --layout-flex-auto;
         @apply --layout-vertical;
         @apply --kano-inset-box-shadow;
     }
     :host section #workspace-panel {
         position: relative;
-        min-width: 38%;
-        max-width: 62%;
+        min-width: 30%;
+        max-width: 50%;
+        width: 30%;
         background-color: var(--kano-app-editor-workspace-background, #f2f2f2);
         @apply --layout-vertical;
     }
@@ -86,6 +86,10 @@ Example:
             padding: 0;
             border-top: 1px solid var(--color-dark);
             border-left: 1px solid var(--color-dark);
+            padding: 0;
+        };
+        --paper-tab-content: {
+            padding: 0 8px;
         };
         --paper-tab-content-unselected: {
             color: rgba(255, 255, 255, 0.5);
@@ -103,8 +107,7 @@ Example:
         margin: 16px;
     }
     :host kano-code-display {
-        width: 466px;
-        flex: 1 0 auto;
+        @apply --flex-layout;
         margin: 16px;
     }
     :host [main] {

--- a/app/elements/kano-part-list-item/kano-part-list-item.html
+++ b/app/elements/kano-part-list-item/kano-part-list-item.html
@@ -12,8 +12,10 @@
                 color: white;
                 @apply --layout-horizontal;
                 @apply --layout-center;
+                color: white;
                 padding: 2px 0px;
                 font-size: 12px;
+                white-space: nowrap;
             }
             iron-icon {
                 --iron-icon-fill-color: #8F9195;
@@ -21,6 +23,9 @@
                 --iron-icon-height: 20px;
                 margin: 4px;
             }
+            .label {
++                min-width: 60px;
++           }
             .controls {
                 @apply --layout-flex;
             }


### PR DESCRIPTION
Related to https://trello.com/c/xyvkqy3T
There is a 'max-width: 100vw;' on kano-app-editor. This stops the bug where the document grows while dragging to resizing the workspace.