### PR TITLE
Update tracking behavior

### DIFF
--- a/app/elements/behaviors/kano-code-tracking-behavior.html
+++ b/app/elements/behaviors/kano-code-tracking-behavior.html
@@ -14,6 +14,10 @@
             path: {
                 type: String,
                 value: ''
+            },
+            preserveSavedSession: {
+                type: Boolean,
+                value: true
             }
         },
         listeners: {


### PR DESCRIPTION
Add `preserveSavedSession` property to prevent Kano Code removing `sessionIds` saved in `localStorage`, which means that these will still be accessible from the app, and sessions won't be reinitiated.

Depends on:
https://github.com/KanoComputing/web-components/pull/114
https://github.com/KanoComputing/kano2-app/pull/234