### PR TITLE
Properly initialise the lightboard

### DIFF
--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -271,7 +271,11 @@
                 }
             },
             ready () {
-                this.set('bitmap', new Array(128));
+                let bitmap = [];
+                for (let i = 0; i < 128; i++) {
+                    bitmap.push("#000000");
+                }
+                this.set('bitmap', bitmap);
             },
             attached () {
                 this._onKeyDown = this._onKeyDown.bind(this);


### PR DESCRIPTION
This is to avoid empty pixels when rendering spritesheets.

cc @mikegreer @paulvarache @abridger 