### PR TITLE
Change padding on code-display

### DIFF
--- a/app/elements/kano-code-display/kano-code-display.html
+++ b/app/elements/kano-code-display/kano-code-display.html
@@ -9,7 +9,7 @@
 		<style include="kano-prism-theme">
 			:host {
 				box-sizing: border-box;
-				padding: 8px 8px 0;
+				padding: 8px 8px 0 0;
 				@apply --layout-horizontal;
 			}
 			:host pre {


### PR DESCRIPTION
Only a small UI tweak here.
I was playing around with line breaks and line numbering, but I think it's OK as it is (for now). The code display overflows horizontally and when there is a line-break, it's part of the code indenting (i.e. a new line-number is appropriate).
There is a small bug when user manually resizes the code-display: the code-view height doesn't reset when going from more lines to less lines, resulting in extra line numbers at the bottom. It seems though that the prism-highlighter output div is not resetting itself. It snaps back to okay when changing tab to canvas and back again.