### PR TITLE
Compute category colors in a scene and process challenge text with any matching variable

### DIFF
--- a/app/elements/kano-app-challenge/kano-challenge-behavior.html
+++ b/app/elements/kano-app-challenge/kano-challenge-behavior.html
@@ -11,7 +11,6 @@
             },
             step: {
                 type: Number,
-                value: 0,
                 notify: true
             },
             selectedStep: {
@@ -32,7 +31,8 @@
                     };
                 },
                 notify: true
-            }
+            },
+            sceneVariables: Object
         },
         computeSelectedStep () {
             let selectedStep;
@@ -58,6 +58,10 @@
             // Update stats if step includes optional hint
             if (selectedStep['set-state'] && selectedStep['set-state'].hints && selectedStep['set-state'].hints.enabled === false) {
                 this.set('hints.total', this.hints.total + 1);
+            }
+
+            if (selectedStep.banner) {
+                selectedStep.banner.text = this._processMarkdown(selectedStep.banner.text);
             }
 
             if (selectedStep.tooltips) {
@@ -129,8 +133,10 @@
             return location;
         },
         _processMarkdown (text) {
-            let reg = /<kano-blockly-block(.*)type="(.+)"(.*)><\/kano-blockly-block>/g;
-            return text.replace(reg, (match, before, type, after) => {
+            let processedText = text,
+                blockReg = /<kano-blockly-block(.*)type="(.+)"(.*)><\/kano-blockly-block>/g;
+
+            processedText = processedText.replace(blockReg, (match, before, type, after) => {
                 let pieces = type.split('#');
                 if (pieces.length > 1) {
                     pieces[0] = this.stepIds[pieces[0]] || pieces[0];
@@ -138,6 +144,13 @@
                 type = pieces.join('#');
                 return `<kano-blockly-block${before}type="${type}"${after}></kano-blockly-block>`;
             });
+
+            //Inject variables to markdown syntax
+            processedText = Object.keys(this.sceneVariables).reduce((acc, key) => {
+                return acc.replace(new RegExp('\\$\\{' + key + '\\}', 'g'), this.sceneVariables[key] || '');
+            }, text);
+
+            return processedText;
         },
         /**
          * Move to the next step or set the challenge as done

--- a/app/elements/kano-scene-editor/kano-scene-editor.html
+++ b/app/elements/kano-scene-editor/kano-scene-editor.html
@@ -11,61 +11,61 @@
 <link rel="import" href="../kano-editor-banner/kano-editor-banner.html">
 <link rel="import" href="../kano-editor-topbar/kano-editor-topbar.html">
 <dom-module id="kano-scene-editor">
-  <style>
-    :host {
-      display: block;
-      @apply(--layout-vertical);
-    }
-    :host kano-app-challenge {
-        @apply(--layout-flex);
-    }
-    :host kano-app-editor {
-        @apply(--layout-flex);
-    }
-    kano-editor-banner {
-        background: #394148;
-        color: white;
-        border-bottom: 1px solid #282E34;
-        height: 82px;
-    }
-    .bolt {
-        background: black;
-        width: 11px;
-        height: 11px;
-        margin: 3px 4px;
-        border-radius: 2px;
-        padding: 3px;
-    }
-    .progress {
-        position: relative;
-        color: white;
-        background: #32393F;
-        height: 22px;
-        border-top: 1px solid #282E34;
-    }
-    .progress .bar {
-        position: absolute;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        background: #e4e6e7;
-        opacity: 0.4;
-        transition: transform 200ms ease-out;
-    }
-    .progress .bar-content {
-        position: absolute;
-        @apply --layout-horizontal;
-    }
-    .progress .story-name {
-        font-size: 14px;
-        font-weight: bold;
-        text-transform: uppercase;
-        margin-top: 2px;
-    }
-  </style>
-  <template>
-      <kano-app-challenge id="challenge"
+    <style>
+        :host {
+          display: block;
+          @apply(--layout-vertical);
+        }
+        :host kano-app-challenge {
+            @apply(--layout-flex);
+        }
+        :host kano-app-editor {
+            @apply(--layout-flex);
+        }
+        kano-editor-banner {
+            background: #394148;
+            color: white;
+            border-bottom: 1px solid #282E34;
+            height: 82px;
+        }
+        .bolt {
+            background: black;
+            width: 11px;
+            height: 11px;
+            margin: 3px 4px;
+            border-radius: 2px;
+            padding: 3px;
+        }
+        .progress {
+            position: relative;
+            color: white;
+            background: #32393F;
+            height: 22px;
+            border-top: 1px solid #282E34;
+        }
+        .progress .bar {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 100%;
+            background: #e4e6e7;
+            opacity: 0.4;
+            transition: transform 200ms ease-out;
+        }
+        .progress .bar-content {
+            position: absolute;
+            @apply --layout-horizontal;
+        }
+        .progress .story-name {
+            font-size: 14px;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 2px;
+        }
+    </style>
+    <template>
+        <kano-app-challenge id="challenge"
                             steps="[[scene.steps]]"
                             on-save="saveApp"
                             on-save-to-storage="saveToStorage"
@@ -75,30 +75,31 @@
                             hint-stats="{{hintStats}}"
                             selected-step="{{selectedStep}}"
                             state="{{state}}"
+                            scene-variables="{{sceneVariables}}"
                             hints="{{hints}}">
-          <kano-app-editor id="editor"
-                            added-parts="{{addedParts}}"
-                            parts="[[parts]]"
-                            default-categories="[[categories]]"
-                            slot="editor"
-                            running="{{running}}"
-                            code="{{code}}"
-                            mode="[[mode]]"
-                            on-share="_pauseAndShare"
-                            challenge-state="[[challengeState]]"
-                            on-lockdown-clicked="_notifyBanner"
-                            hide-leave-alert="[[alertDisabled]]">
+            <kano-app-editor id="editor"
+                             added-parts="{{addedParts}}"
+                             parts="[[parts]]"
+                             default-categories="[[categories]]"
+                             slot="editor"
+                             running="{{running}}"
+                             code="{{code}}"
+                             mode="[[mode]]"
+                             on-share="_pauseAndShare"
+                             challenge-state="[[challengeState]]"
+                             on-lockdown-clicked="_notifyBanner"
+                             hide-leave-alert="[[alertDisabled]]">
                 <div slot="above-code">
                     <kano-editor-topbar exit-url="[[exitUrl]]" user="[[user]]" profile="[[profile]]"></kano-editor-topbar>
                     <kano-editor-banner id="banner"
-                                        head="[[banner.head]]"
-                                        text="[[banner.text]]"
-                                        img-src="[[banner.icon]]"
-                                        img-page="[[banner.imgPage]]"
-                                        show-button="[[banner.showButton]]"
-                                        button-label="[[banner.buttonLabel]]"
-                                        is-last="[[banner.isLast]]"
-                                        on-button-tapped="_bannerButtonTapped"></kano-editor-banner>
+                                       head="[[banner.head]]"
+                                       text="[[banner.text]]"
+                                       img-src="[[banner.icon]]"
+                                       img-page="[[banner.imgPage]]"
+                                       show-button="[[banner.showButton]]"
+                                       button-label="[[banner.buttonLabel]]"
+                                       is-last="[[banner.isLast]]"
+                                       on-button-tapped="_bannerButtonTapped"></kano-editor-banner>
                 </div>
                 <div class="progress" slot="under-code">
                     <div class="bar" id="bar"></div>
@@ -107,9 +108,9 @@
                         <div class="story-name">[[storyName]]</div>
                     </div>
                 </div>
-          </kano-app-editor>
-      </kano-app-challenge>
-  </template>
+            </kano-app-editor>
+        </kano-app-challenge>
+   </template>
 </dom-module>
 <script type="text/javascript">
 
@@ -135,8 +136,7 @@
                 type: Object
             },
             currentStep: {
-                type: Number,
-                value: 0
+                type: Number
             },
             challengeState: {
                 type: Object,
@@ -166,6 +166,10 @@
                 value: false,
                 observer: '_onEndedChanged'
             },
+            sceneVariables: {
+                type: Object,
+                computed: '_computeSceneVariables(categories)'
+            },
             hintStats: {
                 type: Object,
                 notify: true
@@ -188,7 +192,7 @@
             '_addedPartsChanged(addedParts.splices)'
         ],
         _selectedStepChanged (step) {
-            if (!step) {
+            if (!step && !this.modeReady) {
                 return;
             }
             this.computeBanner(step);
@@ -201,6 +205,13 @@
                 duration: 1200,
                 easing: 'ease-in-out'
             });
+        },
+        _computeSceneVariables (categories) {
+            let sceneVariables = {};
+            Object.keys(categories).forEach((key) => {
+                sceneVariables[`${key}_color`] = categories[key].colour;
+            });
+            return sceneVariables;
         },
         computeBanner (step) {
             let iconId;
@@ -348,6 +359,7 @@
             this._computeCategories();
             this._computeParts();
             this._loadVariables();
+            this.currentStep = 0;
             this.async(() => {
                 this._loadDefaultApp();
             });

--- a/app/scripts/kano/make-apps/blockly/color.js
+++ b/app/scripts/kano/make-apps/blockly/color.js
@@ -2,7 +2,7 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#88c440';
+    const COLOR = '#88c440';
 
     let category,
         register = (Blockly) => {
@@ -10,7 +10,7 @@
             init: function () {
                 let json = {
                     id: 'random_colour',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: Blockly.Msg.COLOR_RANDOM,
                     output: 'Colour'
                 };
@@ -51,7 +51,7 @@
                     this.sourceBlock_.updateShape_(option);
                 });
 
-                this.setColour(COLOUR);
+                this.setColour(COLOR);
 
                 this.appendDummyInput()
                     .appendField('new color with')
@@ -113,13 +113,13 @@
         };
 
         category.blocks.forEach((category) => {
-            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOUR);
+            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOR);
         });
     };
     category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_COLOR,
         id: 'color',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: [
             'colour_picker',
             'create_color',

--- a/app/scripts/kano/make-apps/blockly/control.js
+++ b/app/scripts/kano/make-apps/blockly/control.js
@@ -2,14 +2,14 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#1198ff';
+    const COLOR = '#1198ff';
 
     let register = (Blockly) => {
         Blockly.Blocks.loop_forever = {
             init: function () {
                 let json = {
                     id: 'loop_forever',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: `${Blockly.Msg.LOOP_FOREVER_REPEAT} %1 %2`,
                     args0: [
                     {
@@ -44,7 +44,7 @@
             init: function () {
                 let json = {
                     id: 'every_x_seconds',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: `${Blockly.Msg.LOOP_EVERY_REPEAT} %1 %2`,
                     args0: [{
                         type: "input_value",
@@ -98,7 +98,7 @@
             init: function () {
                 let json = {
                     id: 'in_x_time',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: Blockly.Msg.LOOP_IN,
                     args0: [{
                         type: "input_value",
@@ -148,7 +148,7 @@
             init: function () {
                 let json = {
                     id: 'repeat_x_times',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: Blockly.Msg.LOOP_X_TIMES_REPEAT,
                     args0: [{
                         type: "input_value",
@@ -186,13 +186,13 @@
         };
 
         category.blocks.forEach((category) => {
-            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOUR);
+            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOR);
         });
     };
     let category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_CONTROL,
         id: 'control',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: [
             {
                 id: 'repeat_x_times',

--- a/app/scripts/kano/make-apps/blockly/defaults.html
+++ b/app/scripts/kano/make-apps/blockly/defaults.html
@@ -28,7 +28,7 @@
                         break;
                     }
                     case 'string': {
-                        // Check if it is a colours
+                        // Check if it is a color
                         if (/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/.test(values[input])) {
                             shadow[input] = `<shadow type="colour_picker"><field name="COLOUR">${values[input]}</field></shadow>`;
                         }

--- a/app/scripts/kano/make-apps/blockly/events.js
+++ b/app/scripts/kano/make-apps/blockly/events.js
@@ -2,7 +2,7 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#5fc9f3';
+    const COLOR = '#5fc9f3';
 
     let register = (Blockly) => {
 
@@ -12,7 +12,7 @@
                 init: function () {
                     let json = {
                         id: 'part_event',
-                        colour: COLOUR,
+                        colour: COLOR,
                         message0: Blockly.Msg.GLOBAL_EVENT,
                         args0: [{
                             type: "field_dropdown",
@@ -62,7 +62,7 @@
     let category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_EVENTS,
         id: 'events',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: ['part_event']
     });
 

--- a/app/scripts/kano/make-apps/blockly/fun.js
+++ b/app/scripts/kano/make-apps/blockly/fun.js
@@ -2,14 +2,14 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#1198ff';
+    const COLOR = '#1198ff';
 
     let register = (Blockly) => {
         Blockly.Blocks.random_cat = {
             init: function () {
                 let json = {
                     id: 'random_cat',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: Blockly.Msg.RANDOM_CAT,
                     output: 'String'
                 };
@@ -30,7 +30,7 @@
     let category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_FUN,
         id: 'fun',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: ['random_cat']
     });
 

--- a/app/scripts/kano/make-apps/blockly/lists.js
+++ b/app/scripts/kano/make-apps/blockly/lists.js
@@ -2,20 +2,20 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#ccdd1e';
+    const COLOR = '#ccdd1e';
 
     let category,
         register = (Blockly) => {
 
         category.blocks.forEach((category) => {
-            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOUR);
+            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOR);
         });
     };
 
     category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_LISTS,
         id: 'lists',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: [
             'lists_create_empty',
             'lists_create_with',

--- a/app/scripts/kano/make-apps/blockly/logic.js
+++ b/app/scripts/kano/make-apps/blockly/logic.js
@@ -4,7 +4,7 @@
     /**
      * Registers the logic blocks, and creates its category
      */
-    const COLOUR = '#f75846';
+    const COLOR = '#f75846';
 
     let register = (Blockly) => {
 
@@ -45,14 +45,14 @@
         };
 
         category.blocks.forEach((category) => {
-            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOUR);
+            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOR);
         });
     };
 
     let category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_LOGIC,
         id: 'logic',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: [
             'controls_if',
             'logic_compare',

--- a/app/scripts/kano/make-apps/blockly/math.js
+++ b/app/scripts/kano/make-apps/blockly/math.js
@@ -1,7 +1,7 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#ff9800';
+    const COLOR = '#ff9800';
 
     let register = (Blockly) => {
 
@@ -10,7 +10,7 @@
             init: function () {
                 let json = {
                     id: 'math_max',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: '%3 %1 %2',
                     args0: [{
                         type: "input_value",
@@ -56,7 +56,7 @@
             init: function () {
                 let json = {
                     id: 'math_max',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: 'max %1 %2',
                     args0: [{
                         type: "input_value",
@@ -93,7 +93,7 @@
             init: function () {
                 let json = {
                     id: 'math_min',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: 'min %1 %2',
                     args0: [{
                         type: "input_value",
@@ -130,7 +130,7 @@
             init: function () {
                 let json = {
                     id: 'math_sign',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: 'sign %1',
                     args0: [{
                         type: "input_value",
@@ -161,7 +161,7 @@
             init: function () {
                 let json = {
                     id: 'math_random',
-                    colour: COLOUR,
+                    colour: COLOR,
                     message0: 'random number from %1 to %2',
                     args0: [{
                         type: "input_value",
@@ -386,14 +386,14 @@
         Blockly.Pseudo.math_modulo = Blockly.JavaScript.math_modulo;
 
         category.blocks.forEach((category) => {
-            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOUR);
+            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOR);
         });
     };
 
     let category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_MATH,
         id: 'math',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: [
             'math_number',
             'math_arithmetic',

--- a/app/scripts/kano/make-apps/blockly/variables.js
+++ b/app/scripts/kano/make-apps/blockly/variables.js
@@ -1,20 +1,20 @@
 (function (Kano) {
     Kano.MakeApps = Kano.MakeApps || {};
 
-    const COLOUR = '#ffc100';
+    const COLOR = '#ffc100';
 
     let category,
         register = (Blockly) => {
 
         category.blocks.forEach((category) => {
-            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOUR);
+            Kano.Util.Blockly.updateBlockColour(Blockly.Blocks[category.id], COLOR);
         });
     };
 
     category = Kano.MakeApps.Blockly.Defaults.createCategory({
         name: Blockly.Msg.CATEGORY_VARIABLES,
         id: 'variables',
-        colour: COLOUR,
+        colour: COLOR,
         blocks: [
             'math_number',
             'text',


### PR DESCRIPTION
Related to https://trello.com/c/0v6eyvi7
Create a sceneVariables object with a list of category colors that are used in a challenge.
Pass that down to app-challenge (which uses the challenge-behavior).
Challenge-behavior can then use these variables to process the challenge markdown text and inject these variables into string templates.
So the following syntax will work to highlight a word:
"text":"Summon all your <span style=\"color: ${control_color}\">light</span> powers

![screen shot 2017-05-05 at 16 00 01](https://cloud.githubusercontent.com/assets/18003283/25751967/b4f778e4-31ae-11e7-8972-fffe2d830545.png)
