### PR TITLE
Fix issue with reordering parts

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -267,6 +267,7 @@ Polymer({
         this.set('code', this._formatCode({}));
         this.set('background', getDefaultBackground());
         this.save();
+        Kano.MakeApps.Parts.Part.clear();
         this.$.workspace.reset();
         if (!this.remixMode) {
             localStorage.removeItem(`savedApp-${this.mode.id}`);
@@ -460,6 +461,7 @@ Polymer({
     _deletePart (part) {
         let index = this.addedParts.indexOf(part);
         this.splice('addedParts', index, 1);
+        Kano.MakeApps.Parts.freeId(part);
         this.$.workspace.clearSelection();
     },
     onPartReady (e) {

--- a/app/elements/kano-default-workspace/kano-default-workspace.html
+++ b/app/elements/kano-default-workspace/kano-default-workspace.html
@@ -227,8 +227,8 @@
                 </div>
             </div>
             <div class="part-list">
+                <slot name="extra-parts"></slot>
                 <sortable-js handle=".handle" animation="150">
-                    <slot name="extra-parts"></slot>
                     <template is="dom-repeat" items="{{parts}}" as="part" on-dom-change="_partsElementsRepeaterChanged">
                         <div class="part" id$="part-[[part.id]]">
                             <iron-icon class="handle" icon="menu"></iron-icon>
@@ -327,14 +327,13 @@
             _partsAddedOrRemoved (changeRecord) {
                 if (changeRecord && changeRecord.keySplices) {
                     changeRecord.keySplices.forEach(splice => {
-                        let added = splice.added;
+                        const added = splice.added,
+                              removed = splice.removed;
                         added.forEach(key => {
-                            let part = this.get(`parts.${key}`),
-                                partEl;
+                            const part = this.get(`parts.${key}`);
                             if (!part) {
                                 return;
                             }
-                            partEl = this.$$(`#part-${part.id}`);
                             this._partsToAnimateIn.push(part);
                         });
                     });

--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../bower_components/iron-signals/iron-signals.html">
 <link rel="import" href="../../scripts/kano/make-apps/mode/light.html">
 <link rel="import" href="../behaviors/kano-workspace-behavior.html">
+<link rel="import" href="../behaviors/kano-app-element-registry-behavior.html">
 <link rel="import" href="../../scripts/kano/make-apps/parts-api/lightboard.html">
 <link rel="import" href="../kano-bitmap-renderer/kano-bitmap-renderer.html">
 <link rel="import" href="../ui/kano-ui/kano-ui-lightboard.html">

--- a/app/elements/kano-workspace/kano-workspace.html
+++ b/app/elements/kano-workspace/kano-workspace.html
@@ -307,12 +307,6 @@
                     /* Update dropzone reference */
                     this.dropzone = this.$$(`#${this.mode.id}`);
 
-                    this.dropzone.addEventListener('parts-changed', (e) => {
-                        if (e.detail.path === 'parts.splices') {
-                            this.set(e.detail.path, e.detail.value);
-                        }
-                    });
-
                     if (this.dropzone.setBackground) {
                         this.dropzone.setBackground(this.background);
                     }
@@ -389,7 +383,7 @@
             }
             path = e.path;
             if (this.dropzone) {
-                this.dropzone.set(path, e.value);
+                this.dropzone.notifyPath(path, e.value);
             }
             if (path === 'parts.splices') {
                 let keySplices = e.value.keySplices,

--- a/app/scripts/kano/make-apps/parts/part.html
+++ b/app/scripts/kano/make-apps/parts/part.html
@@ -98,6 +98,13 @@
             Part.nameRegistry = {};
         };
 
+        Part.freeId = (model) => {
+            const names = Part.nameRegistry[model.type];
+            if (names) {
+                delete names[model.name];
+            }
+        };
+
         Kano.MakeApps.Parts.Part = Part;
 
     })(window.Kano = window.Kano || {});

--- a/app/scripts/kano/make-apps/parts/parts.html
+++ b/app/scripts/kano/make-apps/parts/parts.html
@@ -32,6 +32,9 @@
             create (model, size) {
                 return new this.partTypes[model.partType](model, size);
             },
+            freeId (model) {
+                this.Part.freeId(model);
+            },
             clear () {
                 return this.Part.clear();
             },


### PR DESCRIPTION
Related to https://trello.com/c/qAIFhbRX/227-kano-code-reordering-stickers-creates-phantom-parts