### PR TITLE
Use volatile events for lightboard frames

### DIFF
--- a/app/scripts/kano/make-apps/hardware-api.html
+++ b/app/scripts/kano/make-apps/hardware-api.html
@@ -165,9 +165,13 @@
                 }
             }
 
-            emit (name, detail) {
+            emit (name, detail, volatile=false) {
                 if (this.socket) {
-                    this.socket.emit(name, detail);
+                    if (volatile) {
+                        this.socket.volatile.emit(name, detail);
+                    } else {
+                        this.socket.emit(name, detail);
+                    }
                 }
             }
 


### PR DESCRIPTION
Prevents socket.io from stacking events when disconnected and sending them all at once when reconnected