### PR TITLE
Unsure, an instance of KC connects to the boards only once

### DIFF
--- a/app/scripts/kano/make-apps/hardware-api.html
+++ b/app/scripts/kano/make-apps/hardware-api.html
@@ -284,7 +284,6 @@
 
             // Returns an already opened connection if exists, otherwise creates a new one and returns it
             static connect (url) {
-                console.log(url);
                 if (!HardwareAPI.sockets[url]) {
                     HardwareAPI.sockets[url] = io.connect(url);
                 }


### PR DESCRIPTION
Related to https://trello.com/c/e9RKwKLp/386-the-very-first-challenge-crashes-the-board-requiring-a-reset-this-seems-to-a-problem-with-the-lights-turn-on-block