### PR TITLE
Update app's user object when receiving progress updates at the end of a challenge

### DIFF
--- a/app/elements/kano-app/kano-app.html
+++ b/app/elements/kano-app/kano-app.html
@@ -133,7 +133,8 @@ Example:
             'kano-error': '_showErrorOnToast',
             'view-loaded': '_viewLoaded',
             'ga-tracking-event': '_trackGAEvent',
-            'ga-page-tracking-event': '_trackGAPage'
+            'ga-page-tracking-event': '_trackGAPage',
+            'update-user-progress': '_updateUserProgress'
         },
         _routeChanged (route) {
             // User not authenticated not actions to be done
@@ -260,6 +261,12 @@ Example:
                 this.set('authCallbacks', null);
             }
         },
+        _fetchUserProgress () {
+            Kano.MakeApps.sdk.api.progress.get()
+                .then((res) => {
+                    this.set('user.profile.levels', res.body.progress.levels);
+                });
+        },
         _onLogin (e) {
             let data = e.detail;
             Kano.MakeApps.sdk.auth.setToken(data.token);
@@ -297,14 +304,17 @@ Example:
             Kano.MakeApps.sdk.api.users.get.byUsername({ username: this.user.username })
                 .then((res) => {
                     this.set('user.profile', res.body.user.profile);
-                    this._updateProgress();
+                    this._fetchUserProgress();
                 });
         },
-        _updateProgress () {
-            Kano.MakeApps.sdk.api.progress.get()
-                .then((res) => {
-                    this.set('user.profile.levels', res.body.progress.levels);
-                });
+        _updateUserProgress (e) {
+            let progress = e.detail 
+                           && e.detail.levels
+                           && e.detail.levels.progress;
+            if (!progress) {
+                return;
+            }
+            this.set('user.profile.levels', progress);
         },
         _userChanged (user) {
             this.debounce('userChanged', () => {

--- a/app/views/kano-view-onboarding/kano-view-onboarding.html
+++ b/app/views/kano-view-onboarding/kano-view-onboarding.html
@@ -275,7 +275,7 @@
         },
         _handleModalAction (e) {
             if (e.detail.trackingEvent) {
-                this.fire('track-event', e.detail.trackingEvent);
+                this.fire('ga-tracking-event', e.detail.trackingEvent);
             }
             if (e.detail.type === 'save') {
                 this.alertDisabled = true;

--- a/app/views/kano-view-story/kano-view-story.html
+++ b/app/views/kano-view-story/kano-view-story.html
@@ -222,6 +222,7 @@
                         if (gamificationEnabled) {
                             this._trackRewards(res.update);
                             this.$['reward-modal'].open(res, this.user);
+                            this.fire('update-user-progress', res.update);
                         } else {
                             this.$['challenge-completed'].set('hints', hints);
                             this.$['challenge-completed'].open();


### PR DESCRIPTION
* Fire `update-user-progress` event after having fetched progress at the end of a challenge in `kano-view-story`
* Catch this and fire `_updateUserProgress` function in `kano-app` to update the `profile.levels` key of the `user` object
* Rename previous `_updateProgress` function to `_fetchUserProgress` to try and make the distinction between this and the new function clearer
* Catch out-dated tracking event in `kano-view-onboarding` and update to new `ga-tracking-event` to ensure that this keeps getting recorded

Fixes the latest issue in this Trello card: https://trello.com/c/7S1Q1TS8/409-inconstancies-between-levels-on-user-in-kano-code-app-and-kano-code