### PR TITLE
Don't fire 'close-parts' when add-parts trigger it

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -138,12 +138,11 @@ Polymer({
     },
     _closePartsModal () {
         this.$['parts-modal'].close();
-        this.$['add-parts'].reset();
-        this.notifyChange('close-parts');
     },
     _partsModalClosed () {
-        this.notifyChange('close-parts');
+        this.$['add-parts'].reset();
         this.partsMenuOpen = false;
+        this.notifyChange('close-parts');
     },
     _addParts (e) {
         this._closePartsModal();


### PR DESCRIPTION
This was falsely triggering an 'opposite action - go to previous step' in validation.
Related to a few bugs on trello.