### PR TITLE
Renaming “Tilt” challenge group to match gamification api

### DIFF
--- a/app/assets/stories/locales/en-US/pixel_action_painting_1/index.json
+++ b/app/assets/stories/locales/en-US/pixel_action_painting_1/index.json
@@ -3,7 +3,7 @@
     "name": "Action Painting Pixels 1",
     "description": "",
     "progress": {
-        "group": "pixel_puzzles"
+        "group": "pixel_action_painting"
     },
     "next":"pixel_action_painting_2",
     "scenes": [{

--- a/app/assets/stories/locales/en-US/pixel_action_painting_2/index.json
+++ b/app/assets/stories/locales/en-US/pixel_action_painting_2/index.json
@@ -3,7 +3,7 @@
     "name": "Action Painting Pixels 2",
     "description": "",
     "progress": {
-        "group": "pixel_puzzles"
+        "group": "pixel_action_painting"
     },
     "next":"pixel_action_painting_3",
     "scenes": [{

--- a/app/assets/stories/locales/en-US/pixel_action_painting_3/index.json
+++ b/app/assets/stories/locales/en-US/pixel_action_painting_3/index.json
@@ -3,7 +3,7 @@
     "name": "Action Painting Pixels 3",
     "description": "",
     "progress": {
-        "group": "pixel_puzzles"
+        "group": "pixel_action_painting"
     },
     "next":"pixel_action_painting_4",
     "scenes": [{

--- a/app/assets/stories/locales/en-US/pixel_action_painting_4/index.json
+++ b/app/assets/stories/locales/en-US/pixel_action_painting_4/index.json
@@ -3,7 +3,7 @@
     "name": "Action Painting Pixels 4",
     "description": "",
     "progress": {
-        "group": "pixel_puzzles"
+        "group": "pixel_action_painting"
     },
     "next":"pixel_action_painting_5",
     "scenes": [{

--- a/app/assets/stories/locales/en-US/pixel_action_painting_5/index.json
+++ b/app/assets/stories/locales/en-US/pixel_action_painting_5/index.json
@@ -3,7 +3,7 @@
     "name": "Action Painting Pixels 5",
     "description": "",
     "progress": {
-        "group": "pixel_puzzles"
+        "group": "pixel_action_painting"
     },
     "next":"",
     "scenes": [{


### PR DESCRIPTION
Both on KCA and on gamification engine we refer to this set of challenges as “pixel_action_painting” so in order to keep all those source of truth in sync, this should use the same name.
One day we will all believe in the same source of truth.