### PR TITLE
"Back to challenges" triggers `window.history.back()`

### DIFF
--- a/app/views/kano-view-story/kano-view-story.html
+++ b/app/views/kano-view-story/kano-view-story.html
@@ -319,10 +319,17 @@
             let extensionId = e.detail;
             page.redirect(`/story/${extensionId}`);
         },
+        _runningOnElectron () {
+            return navigator.userAgent.indexOf("Electron") > -1;
+        },
         goToNextStory (e) {
             let storyId;
             if (!this.story.next) {
-                location.href = Kano.MakeApps.config.PROJECTS_URL;
+                if (this._runningOnElectron()) {
+                    window.history.back();
+                } else {
+                    location.href = Kano.MakeApps.config.PROJECTS_URL;
+                }
                 return;
             }
 


### PR DESCRIPTION
The `view-device` page now requires a `serialNumber` query argument if you want to select a device from that type (specified by the `product` query argument).

Since the `Kano.MakeApps.config.PROJECTS_URL` won't have this information and we have a router in place, the safest solution would be to use what the "back" button is using which is `window.history.back()` in order to go back to the challenges page. We can (hopefully) assume that if you are on the end of a challenge, you probably were on the challenges page.

https://trello.com/c/M3U8cZXB/736-after-finishing-a-block-of-challenges-and-clicking-on-back-to-challenges-it-does-not-show-the-correct-name-or-challenges