### PR TITLE
Moving devDeps into deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,7 @@
     "vinyl-source-stream": "^1.1.0",
     "vulcanize": "^1.15.3",
     "watchify": "^3.7.0",
-    "web-component-tester": "^4.2.2"
-  },
-  "devDependencies": {
+    "web-component-tester": "^4.2.2",
     "chalk": "^1.1.3",
     "connect": "^3.6.0",
     "connect-livereload": "^0.6.0",


### PR DESCRIPTION
The separation was causing the tests to break when building for
production. Most of the deps were dev oriented anyway so this doesn't
reallu change anything, and it should solve the issue.

Related to: https://trello.com/c/IFptKKpF/613-set-up-production-and-staging-environments-for-apps-lightboardkanome-3