### PR TITLE
Do not run crisper on the main index file

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,9 +9,9 @@
 
         <!-- build:env -->
         <script>
-            window.Kano = {};
-            window.Kano.MakeApps = {};
-            window.Kano.MakeApps.config = {};
+            window.Kano = window.Kano || {};
+            window.Kano.MakeApps = window.Kano.MakeApps || {};
+            window.Kano.MakeApps.config = window.Kano.MakeApps.config || {};
             window.Kano.MakeApps.config.ENV = 'staging';
             window.Kano.MakeApps.config.TARGET = 'web';
         </script>

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -55,9 +55,14 @@ module.exports = (gulp, $) => {
         return file.path.indexOf('config.html') !== -1;
     }
 
-    function notBowerComponentHtml(file) {
-        let needTranspile = file.path.split('.').pop() === 'html' && notBowerComponent(file);
-        return needTranspile;
+    function requiresCrisping(file) {
+        let needTranspile = file.path.split('.').pop() === 'html' && notBowerComponent(file),
+            /**
+             * We don't want to preprocess the app's main index as this will
+             * interfere with the htmlReplacement
+             */
+            notIndex = file.path.indexOf('app/index.html') === -1;
+        return needTranspile && notIndex;
     }
 
     gulp.task('external-play-bundle', () => {
@@ -69,7 +74,7 @@ module.exports = (gulp, $) => {
 
     gulp.task('copy-all', () => {
         return gulp.src('app/**/*', { base: 'app' })
-            .pipe($.if(notBowerComponentHtml, $.crisper({ scriptInHead: false })))
+            .pipe($.if(requiresCrisping, $.crisper({ scriptInHead: false })))
             .pipe($.if(isConfig, $.htmlReplace($.utils.getHtmlReplaceOptions())))
             .pipe($.if('*.html', $.utils.htmlAutoprefixerStream()))
             .pipe($.if(notBowerComponentJs, $.transpile()))


### PR DESCRIPTION
and check for `window.Kano` and `window.Kano.MakeApps` before declaring.

Currently, the build process is crisping the main index file wen copying all the files to the `.tmp` directory, so when the `htmlReplace` runs, we're ending up with duplicate declarations of the `config`. Excluding the crisping of the index file allows the `htmlReplace` ot actually replace the stand-in scripts, and ensure that values like the `VERSION` are not being overwritten.