### PR TITLE
Fixing not being able to add parts beyond Part 2

### DIFF
--- a/app/scripts/kano/make-apps/parts/part.html
+++ b/app/scripts/kano/make-apps/parts/part.html
@@ -54,7 +54,7 @@
 
             }
             getUniqueName (value, inc=1) {
-                let newName = (inc === 2) ? `${value} ${inc}` : value;
+                let newName = (inc >= 2) ? `${value} ${inc}` : value;
                 if (Part.nameRegistry[this.type][newName]) {
                     return this.getUniqueName(value, inc + 1);
                 }


### PR DESCRIPTION
Related to: https://trello.com/c/tNHF1mtQ/298-kano-code-reset-workspace-doesnt-truly-reset-the-workspace