### PR TITLE
Close the part editor properly when user clicks outside

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.html
+++ b/app/elements/kano-app-editor/kano-app-editor.html
@@ -311,8 +311,7 @@ Example:
         </paper-dialog>
         <paper-dialog id="edit-part-dialog"
                       entry-animation="from-big-animation"
-                      on-iron-overlay-closed="_partEditorDialogClosed"
-                      no-cancel-on-outside-click>
+                      on-iron-overlay-closed="_partEditorDialogClosed">
             <kano-part-editor
                 id="edit-part-dialog-content"
                 selected="{{selected}}"


### PR DESCRIPTION
Related to: https://trello.com/c/g6OstKNg/506-kano-code-when-the-dialog-is-open-clicking-the-same-item-again-in-the-layer-list-does-this