### PR TITLE
Disambiguate no internet copy in part list

### DIFF
--- a/app/elements/kano-part-list-item/kano-part-list-item.html
+++ b/app/elements/kano-part-list-item/kano-part-list-item.html
@@ -91,7 +91,7 @@
             },
             _computeLabel (connected) {
                 if (this.model.partType === 'data') {
-                    return connected === false ? '(no Internet connection)' : '';
+                    return connected === false ? '(data offline)' : '';
                 } else if (this.model.partType === 'hardware') {
                     return connected === false ? '(disconnected)' : '';
                 }


### PR DESCRIPTION
You may have internet connection but the resource may not be available.


<img width="195" alt="screen shot 2017-06-16 at 15 54 26" src="https://user-images.githubusercontent.com/169328/27231978-5d01a38e-52ac-11e7-9c5b-39d7b1125657.png">


Related to: https://trello.com/c/SZhD13xd/640-change-copy-of-data-parts-when-not-connected-to-data-offline