### PR TITLE
Making HW work during gif generation

### DIFF
--- a/app/scripts/kano/make-apps/hardware-api.html
+++ b/app/scripts/kano/make-apps/hardware-api.html
@@ -459,7 +459,7 @@
             }
 
             _partIsFreeAndMatchesDevice (part, device) {
-                return !this.getDeviceForPart(part.id) && this._partSupportsDevice(part, device)
+                return !this.getDeviceForPart(part.id) && this._partSupportsDevice(part, device);
             }
 
             /**

--- a/app/scripts/kano/make-apps/parts-api/dongle-base.html
+++ b/app/scripts/kano/make-apps/parts-api/dongle-base.html
@@ -16,7 +16,7 @@
                 this.mappingChangedEventListener = this.mappingChangedEventListener.bind(this);
                 if (this.model && this.handlers) {
                     this.appModules.getModule(this.module).on(this.model.id + '-mapping-changed', this.mappingChangedEventListener);
-                    this.remapListeners(null, this.appModules.getModule(this.module).getDeviceForPart(this.id), true);
+                    this.remapListeners(null, this.appModules.getModule(this.module).getDeviceForPart(this.model.id), true);
                 }
             },
             onDestroyed () {
@@ -35,7 +35,6 @@
                 }
             },
             remapListeners (oldDevice, newDevice, notify) {
-
                 if (oldDevice) {
                     Object.keys(this.handlers).forEach((eventName) => {
                         oldDevice.removeListener(eventName, this.handlers[eventName]);

--- a/app/scripts/kano/make-apps/parts/part.html
+++ b/app/scripts/kano/make-apps/parts/part.html
@@ -89,6 +89,7 @@
                 plain.nonvolatileProperties = this.nonvolatileProperties;
                 plain.position = this.position;
                 plain.partType = this.partType;
+                plain.supportedHardware = this.supportedHardware;
                 return plain;
             }
         }


### PR DESCRIPTION
About 30 console.log()s later, the issue was that the simplified representation
of parts didn't include supportedHardware which the HW API uses for matching
devices to parts.

This PR adds the key to the export so we can match against that.

Related to: https://trello.com/c/EhEGAZNf/590-tilt-input-doesnt-work-during-gif-generation