### PR TITLE
This should fix the layout jumping

### DIFF
--- a/app/style/main.css
+++ b/app/style/main.css
@@ -19,6 +19,10 @@ html {
     box-sizing: border-box;
 }
 
+.blocklyWidgetDiv {
+    position: fixed;
+}
+
 .blocklyWidgetDiv .goog-menu {
     border-radius: 4px !important;
     border: 0px;


### PR DESCRIPTION
Related to: https://trello.com/c/PSIBT2o6/732-rc-the-coding-window-is-only-filling-half-the-screen