### PR TITLE
Load parts with the correct colours again

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -432,7 +432,7 @@ Polymer({
         this.set('addedParts', addedParts);
         // Force a color update and a register block to make sure the loaded code will be
         // rendered with the right colors
-        this.updateColors();
+        Kano.MakeApps.Utils.updatePartsColors(this.addedParts);
         this.$['root-view'].computeBlocks();
         this.set('code', savedApp.code);
         this.set('background', savedApp.background);


### PR DESCRIPTION
Related to: https://trello.com/c/HElxPbzX/814-kano-code-blocks-load-in-as-the-wrong-color