### PR TITLE
Tear down the hardware api on detached only for older shares

### DIFF
--- a/app/elements/kano-app-player/kano-app-player.html
+++ b/app/elements/kano-app-player/kano-app-player.html
@@ -211,6 +211,16 @@
                 this.running = false;
                 this.component.stop();
             },
+            detached () {
+                this.stop();
+                // Previous versions of the shares, didn't tear down the hardware once detached
+                // This detects these old versions and manually tears down thei hardware api
+                if (!this.component.hwAPI
+                    && this.component.appModules
+                    && this.component.appModules.modules.lightboard) {
+                    this.component.appModules.modules.lightboard.api.tearDown();
+                }
+            },
             getWorkspace () {
                 return this.component.workspace;
             },

--- a/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
+++ b/app/elements/kano-workspace-lightboard/kano-workspace-lightboard.html
@@ -340,16 +340,6 @@
             stop () {
                 Kano.MakeApps.PartsAPI.lightboard.stop.apply(this);
                 this.reset();
-                // IF I AM A SHARE STOP HARDWARE API
-                // This is a dirty check that will be true if inside a share
-                // Newer shares take care of tearing themselves down automatically
-                // this allows older shares to disconnect from hardware once they are detached
-                if (
-                    this.parentNode.tagName.toLowerCase() === 'kano-ui-viewport'
-                    && this.appModules.modules.lightboard.api
-                ) {
-                    this.appModules.modules.lightboard.api.tearDown();
-                }
             },
             reset () {
                 this.clear();


### PR DESCRIPTION
https://trello.com/c/7tot7ANh/952-p2-dev-rpk-pressing-pause-on-the-expanded-share-card-when-also-in-live-mode-stops-the-expanded-share-showing-all-together