### PR TITLE
Update AppModules with new parts when loading app

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -437,7 +437,8 @@ Polymer({
      */
     load (savedApp, parts) {
         let addedParts,
-            part;
+            part,
+            partsDict;
         if (!savedApp) {
             return;
         }
@@ -455,6 +456,11 @@ Polymer({
         });
         savedApp.code = this._formatCode(savedApp.code);
         this.set('addedParts', addedParts);
+
+        // Update AppModules
+        partsDict = this.$.workspace.getPartsDict();
+        Kano.AppModules.loadParts(partsDict);
+
         // Force a color update and a register block to make sure the loaded code will be
         // rendered with the right colors
         Kano.MakeApps.Utils.updatePartsColors(this.addedParts);
@@ -779,9 +785,6 @@ Polymer({
     },
     applyHiddenClass () {
         return this.running ? '' : 'hidden';
-    },
-    _getRunningStatus (running) {
-        return running ? 'running' : 'stopped';
     },
     getMakeButtonLabel () {
         if (this.running) {


### PR DESCRIPTION
Related to https://trello.com/c/9zF3oNMB and https://trello.com/c/X26dScQN
Easiest reconstruction of the bug was:
- Have an app with a box part with x background
- Load a kcode file with a box part with y background
- Toggle app running and the box part will switch its background back to x

This is because AppModules '_parts' property didn't get refreshed at the point of loading the app, so lifecycle methods were run on the old part elements.

