### PR TITLE
Fix infinite loop in npm install and add scripts to select level of i…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "prepare": "npm install && bower install",
-    "start": "node_modules/.bin/gulp serve-prod",
+    "start": "gulp serve-prod",
     "test": "gulp wct && cucumber-js tests",
     "build": "gulp build",
     "dev": "gulp dev",
+    "watch": "gulp watch",
     "content-snap": "bash kano-content-package.sh",
-    "postinstall": "bower install && gulp build"
+    "install:all": "npm install && bower install",
+    "install:all:build": "npm install && bower install && gulp build"
   },
   "engines": {
     "node": "4.5.0"


### PR DESCRIPTION
…nstall

* Remove prepare script with npm install instruction (cause of infinite loop)
* Add `install:all` script to install npm and bower packages
* Add `install:all:build` script to install all and build the project

Before `npm i` would install all packages and build the project, which is not what you always want. Now you can select what you want to do.
NOTE: `npm i` ONLY installs npm packages now (so if you want to run a bower install, either call `bower install` or run `npm run install:all`