### PR TITLE
Restart app when adding parts

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -93,6 +93,7 @@ Polymer({
     observers: [
         'selectedPartChanged(selected.*)',
         'backgroundChanged(background.*)',
+        'resetAppState(addedParts.splices)',
         'updateColors(addedParts.splices)',
         'updateColors(defaultCategories.*)',
         '_codeChanged(code.*)',
@@ -108,7 +109,6 @@ Polymer({
         'edit-background': '_openBackgroundDialog',
         'iron-resize': '_refitPartModal',
         'feature-not-available-offline': '_openOfflineDialog',
-        //As opposed to 'iron-overlay-opened', 'opened-changed' will notify when an animation starts
         'opened-changed': '_manageModals'
     },
      //Make sure that no conflicting modals are opened at the same time


### PR DESCRIPTION
**Problem:** Sensors didn't display values in challenges. It was because 'start' lifecycle methods didn't run on added parts.
**Solution:** Reset app when adding parts. This will make sure that module lifecycle methods run.
Related to https://trello.com/c/cmvLaqsY