### PR TITLE
Change where the motion-sensor is reset on starting

### DIFF
--- a/app/scripts/kano/make-apps/parts-api/motion-sensor.html
+++ b/app/scripts/kano/make-apps/parts-api/motion-sensor.html
@@ -21,9 +21,9 @@
 
                 this.spring = new Kano.MakeApps.Spring(1, 400, 20);
                 this.spring.snap(0);
+                this.reset();
             },
             start () {
-                this.reset();
                 PartsAPI.DongleBase.start.apply(this, arguments);
                 this._updateLoop = requestAnimationFrame(this._generateUpdate);
             },
@@ -33,7 +33,9 @@
                 this.reset();
             },
             reset () {
-                this.set('model.lastProximityValue', 0);
+                if (this.model && this.model.lastProximityValue) {
+                    this.set('model.lastProximityValue', 0);
+                }
                 this._listeners = [];
             },
             _generateUpdate () {


### PR DESCRIPTION
The Problem
-----------
The motion-sensor is currently being reset when the `start` method is called. This means that the `_listeners` queue is cleared. Since this happens after the app has loaded in the app player, and is already running, this clears the queue that has just been set up. Apps that are relying on listeners for zone changes are therefore not triggering the callbacks for these.

The Solution
------------
Since the motion-sensor is reset when stopping, it seems that we can get away with only resetting the motion-sensor part when it is attached, rather than when starting. The allows the part to be reset as required without clearing the `_listeners` queue.

This addresses the bug in the Trello card below. While the expanded shares are in fact receiving data from the motion sensor, there is a problem when zone listeners are needed as described above. So this should fix all the issues.

Trello card: https://trello.com/c/OtRSEuQR/994-3-expanded-share-card-doesnt-read-data-from-motion-sensor