### PR TITLE
Change Google Map API key

### DIFF
--- a/app/scripts/config/development.html
+++ b/app/scripts/config/development.html
@@ -8,7 +8,7 @@
         Kano.MakeApps.config.WORLD_URL = "http://localhost:5000";
         Kano.MakeApps.config.PROJECTS_URL = Kano.MakeApps.config.WORLD_URL + "/projects";
         Kano.MakeApps.config.KANO_CODE_URL = "http://localhost:4000";
-        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyCk3HlbKJV4-ZJcRqwViaZ8mCIKU2LsnE0";
+        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyB3CO_eTW7T_bwAQFewuUqwNElg_b9B6lQ";
 
     })(window.Kano = window.Kano || {});
 </script>

--- a/app/scripts/config/production.html
+++ b/app/scripts/config/production.html
@@ -7,7 +7,7 @@
         Kano.MakeApps.config.WORLD_URL = "https://world.kano.me";
         Kano.MakeApps.config.PROJECTS_URL = Kano.MakeApps.config.WORLD_URL + "/projects";
         Kano.MakeApps.config.KANO_CODE_URL = "https://apps-lightboard.kano.me";
-        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyDPqXOx9Xsyjw2xP9VLcjtJQl8sbUWznqk";
+        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyB3CO_eTW7T_bwAQFewuUqwNElg_b9B6lQ";
         Kano.MakeApps.config.VOICE_API_KEY = "99f3958bbbed4c9abe8d22ad6fabd55f";
 
     })(window.Kano = window.Kano || {});

--- a/app/scripts/config/rc.html
+++ b/app/scripts/config/rc.html
@@ -6,7 +6,7 @@
         Kano.MakeApps.config.WORLD_URL = "https://world-staging.kano.me";
         Kano.MakeApps.config.PROJECTS_URL = Kano.MakeApps.config.WORLD_URL + "/projects";
         Kano.MakeApps.config.KANO_CODE_URL = "https://apps-lightboard-staging.kano.me";
-        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyDPqXOx9Xsyjw2xP9VLcjtJQl8sbUWznqk";
+        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyB3CO_eTW7T_bwAQFewuUqwNElg_b9B6lQ";
 
     })(window.Kano = window.Kano || {});
 </script>

--- a/app/scripts/config/staging.html
+++ b/app/scripts/config/staging.html
@@ -6,7 +6,7 @@
         Kano.MakeApps.config.WORLD_URL = "https://world-staging.kano.me";
         Kano.MakeApps.config.PROJECTS_URL = Kano.MakeApps.config.WORLD_URL + "/projects";
         Kano.MakeApps.config.KANO_CODE_URL = "https://apps-lightboard-staging.kano.me";
-        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyDPqXOx9Xsyjw2xP9VLcjtJQl8sbUWznqk";
+        Kano.MakeApps.config.GOOGLE_API_KEY = "AIzaSyB3CO_eTW7T_bwAQFewuUqwNElg_b9B6lQ";
 
     })(window.Kano = window.Kano || {});
 </script>


### PR DESCRIPTION
We now use team-infrastructure@kano.me account's key with no referrer restriction.
Related to https://trello.com/c/yaHLAuMW