### PR TITLE
Challenge progress/autoshare issues

### DIFF
--- a/app/assets/stories/locales/en-US/motion_gesture_1/index.json
+++ b/app/assets/stories/locales/en-US/motion_gesture_1/index.json
@@ -5,7 +5,7 @@
     "progress": {
         "group": "motion_sensor"
     },
-    "next":"motion_gesture_1",
+    "next":"motion_gesture_2",
     "scenes": [{
         "id": "_0",
         "component": "common/editor",

--- a/app/assets/stories/locales/en-US/motion_guitar_1/index.json
+++ b/app/assets/stories/locales/en-US/motion_guitar_1/index.json
@@ -9,6 +9,7 @@
     "scenes": [{
         "id": "_0",
         "component": "common/editor",
+        "autoshare_disabled": true,
         "data_path": "steps.json",
         "show_remix_options": true
     }]

--- a/app/assets/stories/locales/en-US/motion_guitar_2/index.json
+++ b/app/assets/stories/locales/en-US/motion_guitar_2/index.json
@@ -9,6 +9,7 @@
     "scenes": [{
         "id": "_0",
         "component": "common/editor",
+        "autoshare_disabled": true,
         "data_path": "steps.json",
         "show_remix_options": true
     }]

--- a/app/assets/stories/locales/en-US/motion_guitar_3/index.json
+++ b/app/assets/stories/locales/en-US/motion_guitar_3/index.json
@@ -9,6 +9,7 @@
     "scenes": [{
         "id": "_0",
         "component": "common/editor",
+        "autoshare_disabled": true,
         "data_path": "steps.json",
         "show_remix_options": true
     }]

--- a/app/assets/stories/locales/en-US/motion_pong_2/steps.json
+++ b/app/assets/stories/locales/en-US/motion_pong_2/steps.json
@@ -773,10 +773,10 @@
         "sticker"
     ],
     "modules": [
-        "variables",
+        "events",
         "control",
         "math",
-        "events"
+        "variables"
     ],
     "variables": [
         "ballSpeedX",


### PR DESCRIPTION
Fixes:
- https://trello.com/c/BqEBWMPU/940-p2-mac-msk-build285-virtual-guitar-2-autosaves-even-though-there-is-a-continuation
- https://trello.com/c/ljcusiuz/944-p3-mac-msk-build285-virtual-guitar-3-is-autosharing-even-though-it-is-continuing
- https://trello.com/c/Z4JWIFnH/965-p3-mac-msk-build286-in-challenges-the-events-blocks-are-not-on-the-top-of-the-stack
- https://trello.com/c/EZ6Vb8QQ/968-p2-mac-msk-build286-intro-to-gestures-clicking-next-just-shows-the-same-challenge