### PR TITLE
Fixing a z-index issue while dragging blocks

### DIFF
--- a/app/elements/kano-blockly-flyout/kano-blockly-flyout.html
+++ b/app/elements/kano-blockly-flyout/kano-blockly-flyout.html
@@ -284,7 +284,8 @@
                     };
                 },
                 createBlock (originBlock) {
-                    let block;
+                    let block,
+                        onChange;
                     if (originBlock.disabled) {
                         return;
                     }
@@ -299,6 +300,20 @@
                         Blockly.Events.fire(new Blockly.Events.Create(block));
                     }
                     this.fire('block-created');
+
+
+                    /* Add a class with elevated z-index when dragging
+                       the block out of the toolbox and register a listener to
+                       remove it when the dragging is over. */
+                    onChange = (e) => {
+                        if (e.type === Blockly.Events.MOVE && e.blockId === block.id) {
+                            Blockly.utils.removeClass(block.svgGroup_, 'initialDrag');
+                            block.workspace.removeChangeListener(onChange);
+                        }
+                    };
+                    Blockly.utils.addClass(block.svgGroup_, 'initialDrag');
+                    block.workspace.addChangeListener(onChange);
+
                     return block;
                 },
                 _placeNewBlock (originBlock) {

--- a/app/elements/kano-blockly/kano-blockly-style.html
+++ b/app/elements/kano-blockly/kano-blockly-style.html
@@ -169,6 +169,9 @@
             rect.blocklyMainBackground, ::slotted(* rect.blocklyMainBackground) {
                 opacity: 0 !important;
             }
+            .initialDrag, ::slotted(.initialDrag) {
+                z-index: 1 !important;
+            }
         </style>
     </template>
 </dom-module>

--- a/app/elements/kano-blockly/kano-blockly.html
+++ b/app/elements/kano-blockly/kano-blockly.html
@@ -110,7 +110,7 @@ Example:
             }
         </style>
         <div id="workspace" class="injectionDiv">
-            <kano-blockly-toolbox id="toolbox" toolbox="[[toolbox]]" on-block-created="_onToolboxBlockCreated" auto-close hidden$="{{noToolbox}}"></kano-blockly-toolbox>
+            <kano-blockly-toolbox id="toolbox" toolbox="[[toolbox]]" auto-close hidden$="{{noToolbox}}"></kano-blockly-toolbox>
             <svg id="svg" xmlns="http://www.w3.org/2000/svg"></svg>
         </div>
         <div class="omnibox-wrapper" id="omnibox-wrapper" on-tap="_omniboxWrapperTapped">
@@ -297,12 +297,6 @@ Example:
         _preventSubmit (e) {
             e.preventDefault();
             e.stopPropagation();
-        },
-        _onToolboxBlockCreated () {
-            this.$.svg.style.zIndex = 1;
-        },
-        _onToolboxEndDrag () {
-            this.$.svg.style.zIndex = '';
         },
         _createWorkspace (svg, options) {
             options.parentWorkspace = null;
@@ -544,7 +538,6 @@ Example:
                     };
                     this.workspace.fireChangeListener(ev);
                     this.lastCreated = null;
-                    this._onToolboxEndDrag();
                 } else if (e.type === Blockly.Events.MOVE) {
                     // The event type is `move` and the block concerned was not just created
                     this.fire('block-move');


### PR DESCRIPTION
Related to: https://trello.com/c/6VrIktU9/942-p3-mac-msk-build285-virtual-guitar-3-when-moving-a-block-from-the-bar-on-the-left-part-of-the-code-covers-the-block-on-the-left