### PR TITLE
Use the polymer shorthand element selector function to return our `sc…

### DIFF
--- a/app/elements/kano-story-scene/kano-story-scene.html
+++ b/app/elements/kano-story-scene/kano-story-scene.html
@@ -187,7 +187,7 @@
             this.overlayHidden = false;
         },
         resetAppState () {
-            this.$['scene-editor'].resetAppState();
+            this.$$("#scene-editor").resetAppState();
         }
     });
 </script>


### PR DESCRIPTION
Fix for [P2 Mac MSK Build286 - Code pong 5](https://trello.com/c/j2Rx6HAC/967-p2-mac-msk-build286-code-pong-5-nothing-happens-when-you-click-the-restart-button)

The issue is with kano components that are declared within a template withing the container template not being added to the polymer [quick find object](https://www.polymer-project.org/1.0/docs/devguide/local-dom#node-finding) (`this.$`). 

```html
<template>
        <iron-lazy-pages class="scene" attr-for-selected="name" selected="[[name]]" restamp>
            <template is="iron-lazy-page" name="editor">
                <kano-scene-editor id="scene-editor"
                                   user="[[user]]"
                                   store="{{store}}"
                                   story="[[story]]"
                                   scene="[[sceneData]]"
                                   on-scene-done="sceneCompleted"
                                   added-parts="{{addedParts}}"></kano-scene-editor>
            </template>
        </iron-lazy-pages>
        </iron-lazy-pages>
    </template>
```

Here `this.$['scene-editor']` fails! We use `this.$$("#scene-editor")` instead.