### PR TITLE
Change part editor fitInto property in app-editor

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -511,7 +511,7 @@ Polymer({
         this.$['edit-part-dialog'].close();
     },
     _toggleFullscreenModal (isFullScreen) {
-        this.$['edit-part-dialog'].fitInto = isFullScreen ? window : this.$['root-view'];
+        this.$['edit-part-dialog'].fitInto = isFullScreen ? window : this.$['blocks-panel'];
         this.$['edit-part-dialog'].withBackdrop = isFullScreen;
         this.toggleClass('large-modal', isFullScreen, this.$['edit-part-dialog-content']);
         //If modal is not fullscreen, use a custom overlay


### PR DESCRIPTION
When we had a large banner in a challenge, part-editor would't fit on the screen. It's because the part-editor modal would position itself to root-view and that didn't include the editor-banner. With this change the popup positions itself to the whole blocks-panel in the app-editor.
QA agreed this should go to RC.
https://trello.com/c/khYmTs39