### PR TITLE
Fixing a race in the build

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -36,7 +36,7 @@
         <title>Kano Code</title>
         <link rel="stylesheet" href="/style/main.css" inline>
         <!-- build:style -->
-        <!-- endbuild-->
+        <!-- endbuild -->
         <script type="text/javascript">
             // GTM custom data passing
             window.dataLayer = [];

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -102,7 +102,8 @@ module.exports = (gulp, $) => {
             'copy-all',
             'shards',
             'split',
-            ['copy-index', 'blockly-media', 'assets', 'workers', 'i18n', 'kano-code-lib'],
+            ['blockly-media', 'assets', 'workers', 'i18n', 'kano-code-lib'],
+            'copy-index',
             'compress',
             'sw',
             'external-play-bundle', done);


### PR DESCRIPTION
Some weird race condition was causing inline scripts to be removed from
the index.html file which broke the build. Moving the copy-index after
the parallel tasks seems to fix the issue for now, but I couldn't
actually track it down to exactly what was causing the removal (none of
the parallel tasks seem to affect the build).