### PR TITLE
Fix setting volume in synth and speaker parts

### DIFF
--- a/app/elements/part/kano-part-speaker/kano-part-speaker.html
+++ b/app/elements/part/kano-part-speaker/kano-part-speaker.html
@@ -53,6 +53,7 @@
                     this.oscillatorsGain = this.ctx.createGain();
                     this.oscillatorsGain.connect(this.output);
                     this.oscillatorsGain.gain.value = 0.2;
+                    this.setVolume(this.volume);
                 } catch (e) {
                     this.webAudioSupported = false;
                 }
@@ -127,6 +128,10 @@
                 return source;
             },
             setVolume (volume) {
+                if (!this.model || !this.gainControl) {
+                    return;
+                }
+
                 let value;
                 this.volume = Math.min(Math.max(volume, 0), 100);
                 //the maximum value is limited to an ear-friendly sound pressure level

--- a/app/elements/part/kano-part-synth/kano-part-synth.html
+++ b/app/elements/part/kano-part-synth/kano-part-synth.html
@@ -37,6 +37,7 @@
                     this.gainControl = this.ctx.createGain();
                     this.gainControl.connect(this.ctx.destination);
                     this.output = this.gainControl;
+                    this.setVolume(this.volume);
                 } catch (e) {
                     this.webAudioSupported = false;
                 }
@@ -60,6 +61,9 @@
                 this.setVolume(this.volume);
             },
             setVolume (volume) {
+                if (!this.model || !this.gainControl) {
+                    return;
+                }
                 let value;
                 this.volume = Math.min(Math.max(volume, 0), 100);
                 //the maximum value is limited to an ear-friendly sound pressure level


### PR DESCRIPTION
Previously the **gain value** was not set properly in some scenarios. (for example when sharing a 'synth start' block without a 'set volume' block).
It was because at the time of calling ```setVolume``` as the observer callback of model.muted, the audio context wasn't ready.
With the current change the ```setVolume``` is called after setting up the context, which makes sure that the this.volume value is used on the gain.