### PR TITLE
Auto-scroll in challenges when target has negative top or left value

### DIFF
--- a/app/elements/kano-app-challenge/kano-challenge-ui.html
+++ b/app/elements/kano-app-challenge/kano-challenge-ui.html
@@ -514,7 +514,9 @@ Example:
                     block;
                 if (target &&
                         (target.top + target.height > workspaceRect.top + workspaceRect.height) ||
-                        (target.left + target.width > workspaceRect.left + workspaceRect.width)) {
+                        (target.left + target.width > workspaceRect.left + workspaceRect.width) ||
+                        (target.top < 0) ||
+                        (target.left < 0)) {
                     block = this.getTargetBlock(location.block);
                     workspace.scrollBlockIntoView(block, true);
                 }


### PR DESCRIPTION
As a result, auto-pan will happen if a target block is 'left' or 'top' offscreen.
Related to https://trello.com/c/CKQzdPME