### PR TITLE
Sets the app_id on the config

### DIFF
--- a/app/scripts/config/default.html
+++ b/app/scripts/config/default.html
@@ -11,6 +11,7 @@
         Kano.MakeApps.config.VOICE_API_KEY = "65b85d9c94094d62bddfd37acd5786b4";
         Kano.MakeApps.config.WEATHER_API_KEY = "79f483fba81614f1e7d1fea5a28b9750";
         Kano.MakeApps.config.HARDWARE_API_URL = "http://localhost:13370";
+        Kano.MakeApps.config.APP_ID = "kano_code";
         Kano.MakeApps.config.TRACKING = {
             SCHEMA: "kano_code"
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kano-code",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Addresses issues disambiguating tracking events from apps with different versions.

Also bumps the version, since `1.0.6` is already in production.

Depends on this PR: https://github.com/KanoComputing/web-components/pull/171