### PR TITLE
Fix synth set wave method and rework the monotron filter

### DIFF
--- a/app/elements/part/kano-part-synth/kano-part-synth.html
+++ b/app/elements/part/kano-part-synth/kano-part-synth.html
@@ -27,6 +27,14 @@
                 volume: {
                     type: Number,
                     value: 100
+                },
+                waveType: {
+                    type: String,
+                    value: 'sine'
+                },
+                volumeAttenuation: {
+                    type: Number,
+                    value: 0.00075
                 }
             },
             ready () {
@@ -66,19 +74,20 @@
                 }
                 let value;
                 this.volume = Math.min(Math.max(volume, 0), 100);
-                //the maximum value is limited to an ear-friendly sound pressure level
-                value = this.model.muted ? 0 : (this.volume * 0.00075);
+                //the maximum value is limited to an ear-friendly volume
+                this.volumeAttenuation = /sine|triangle/.test(this.waveType) ? 0.00185 : 0.00075;
+                value = this.model.muted ? 0 : (this.volume * this.volumeAttenuation);
                 if (this.gainControl) {
                     this.gainControl.gain.value = value;
                 }
             },
             _createMonotron () {
-                let monotron = new Kano.Music.Monotron(this.ctx);
-
-                monotron.lfo.frequency.value = 30;
-                monotron.lfoGain.gain.value = 100;
-                monotron.vcf.frequency.value = 2500;
-
+                let opts = {
+                    ctx: this.ctx,
+                    waveType: this.waveType
+                };
+                this.setVolume(this.volume);
+                let monotron = new Kano.Music.Monotron(opts);
                 monotron.connect(this.output);
 
                 return monotron;
@@ -126,9 +135,14 @@
                 }
             },
             setSynthWave (wave) {
-                if (this.synth) {
-                    this.synth.vco.type = wave;
+                this.waveType = wave;
+                if (!this.synth) {
+                    return;
                 }
+                this.synth.setWaveType(wave);
+
+                // Set volume as the attenuation depends on the wave type
+                this.setVolume(this.volume);
             }
         });
     })();

--- a/app/scripts/kano/music/monotron/monotron.html
+++ b/app/scripts/kano/music/monotron/monotron.html
@@ -2,24 +2,34 @@
     (function (Kano) {
 
         class Monotron {
-            constructor (ctx) {
-                this.ctx = ctx;
+            constructor (opts) {
+                this.ctx = opts.ctx;
                 this.vco = this.ctx.createOscillator();
-                this.lfo = this.ctx.createOscillator();
-                this.lfoGain = this.ctx.createGain();
-                this.vcf = this.ctx.createBiquadFilter();
                 this.output = this.ctx.createGain();
-
-                this.vco.connect(this.vcf);
-                this.vcf.connect(this.output);
-                this.lfo.connect(this.lfoGain);
-                this.lfoGain.connect(this.vcf.frequency);
-
                 this.output.gain.value = 0;
-                this.vco.type = 'sawtooth';
-                this.lfo.type = 'triangle';
+
+                this.vcf = this.ctx.createBiquadFilter();
+                this.vcf.type = 'bandpass';
+                this.vcf.frequency.value = 5000;
+                this.vcf.Q.value = 10;
+
+                this.setWaveType(opts.waveType);
+
+                this.vco.connect(this.output);
                 this.vco.start(this.ctx.currentTime);
-                this.lfo.start(this.ctx.currentTime);
+            }
+
+            setWaveType (wave) {
+                // Connect the vcf filter depending on the wave type
+                if (this.filterOn && (wave === 'sine' || wave === 'triangle')) {
+                    this.vco.disconnect(this.vcf);
+                    this.filterOn = false;
+                } else if (!this.filterOn && (wave === 'square' || wave === 'sawtooth')) {
+                    this.vco.connect(this.vcf);
+                    this.filterOn = true;
+                }
+
+                this.vco.type = wave;
             }
 
             noteOn (freq, time) {


### PR DESCRIPTION
If the **waveType** was set in a kcode app before starting the synth or playing a sound, the waveType wasn't applied. I fixed that and also reworked the **monotron** filter + took out the filtering on sine and triangle waves.

Ticket: https://trello.com/c/1EvksaAs