### PR TITLE
Request signup from reward model fix

### DIFF
--- a/app/views/kano-view-story/kano-view-story.html
+++ b/app/views/kano-view-story/kano-view-story.html
@@ -66,7 +66,7 @@
         </paper-dialog>
         <kano-challenge-completed-modal id="challenge-completed"></kano-challenge-completed-modal>
         <kano-reward-modal id="reward-modal"
-                           on-second-action="_openSignup"
+                           on-request-signup="_openSignup"
                            sound="/assets/audio/samples/challenge_complete.wav"></kano-reward-modal>
         <kano-alert id="leave-alert"
                     heading="[[localize('NOT_FINISHED', 'Oh oh.. not finished yet!')]]"


### PR DESCRIPTION
I think it worked before because we used the local version of kano-reward-model, but the event's name changed in web-components.