### PR TITLE
speaker_stop: Use part.name instead of hardcoding

### DIFF
--- a/app/scripts/kano/make-apps/parts/speaker.html
+++ b/app/scripts/kano/make-apps/parts/speaker.html
@@ -136,10 +136,10 @@
                     };
                 }
             },{
-                block: () => {
+                block: (part) => {
                     return {
                         id: 'speaker_stop',
-                        message0: 'Speaker: stop',
+                        message0: `${part.name}: stop`,
                         previousStatement: null,
                         nextStatement: null
                     };


### PR DESCRIPTION
Related to: https://trello.com/c/F31ejZ43/1025-kano-code-multiple-speakers-stop-function-incorrectly-named-1