### PR TITLE
Inject app styles in old shares

### DIFF
--- a/app/elements/kano-app-player/kano-app-player.html
+++ b/app/elements/kano-app-player/kano-app-player.html
@@ -157,7 +157,7 @@
             },
             _onAppFileLoad () {
                 let root = Polymer.dom(this.root),
-                    c;
+                    c, styleElm;
                 // Create the component. Older shares were generated with the tagName `kano-user-component`
                 try {
                     c = this.create(`kano-${this.slug}`);
@@ -175,7 +175,14 @@
                     }
                     return Polymer.dom(this.root).querySelector(id);
                 };
+                /** Inject app styles on old shares */
                 root.appendChild(c);
+                styleElm = c.$$('style');
+                if (!styleElm) {
+                    let styleElm = document.createElement('style');
+                    styleElm.innerHTML = c.appModules.componentStyles;
+                    c.root.appendChild(styleElm);
+                }
                 if (this.$.container) {
                     root.removeChild(this.$.container);
                     this.$.container = null;

--- a/app/scripts/kano/app-modules/app-modules.html
+++ b/app/scripts/kano/app-modules/app-modules.html
@@ -6,6 +6,27 @@
             constructor () {
                 this.modules = {};
             }
+            get componentStyles () {
+                return `
+                    :host {
+                        position: relative;
+                    }
+                    kano-ui-viewport {
+                        position: absolute;
+                        top: 0px;
+                        left: 0px;
+                        width: 100%;
+                        height: 100%;
+                    }
+                    kano-ui-viewport * {
+                        position: absolute;
+                    }
+                    .workspace {
+                        width: 100%;
+                        height: 100%;
+                    }
+                `
+            }
 
             config (config) {
                 Object.keys(this.modules).forEach(name => {
@@ -69,23 +90,7 @@
                     <dom-module id="kano-${componentName}">
                         <template>
                             <style>
-                                :host {
-                                    position: relative;
-                                }
-                                kano-ui-viewport {
-                                    position: absolute;
-                                    top: 0px;
-                                    left: 0px;
-                                    width: 100%;
-                                    height: 100%;
-                                }
-                                kano-ui-viewport * {
-                                    position: absolute;
-                                }
-                                .workspace {
-                                    width: 100%;
-                                    height: 100%;
-                                }
+                                ${this.componentStyles}
                             </style>
                             <kano-ui-viewport mode="scaled"
                                         view-width="${mode.workspace.viewport.width}"


### PR DESCRIPTION
Older share have the app style outside of the tag element which causes our polymer 2.0 apps to not render the style element. This PR checks for the styles on a share component and injects them if they don't exists.