### PR TITLE
Mock out the hardware api for web apps

### DIFF
--- a/app/scripts/config/default.html
+++ b/app/scripts/config/default.html
@@ -10,6 +10,7 @@
         Kano.MakeApps.config.VOICE_API_URL = "//api.voicerss.org";
         Kano.MakeApps.config.VOICE_API_KEY = "65b85d9c94094d62bddfd37acd5786b4";
         Kano.MakeApps.config.WEATHER_API_KEY = "79f483fba81614f1e7d1fea5a28b9750";
+        Kano.MakeApps.config.USE_HARDWARE_API = false;
         Kano.MakeApps.config.HARDWARE_API_URL = "http://localhost:13370";
         Kano.MakeApps.config.APP_ID = "kano_code";
         Kano.MakeApps.config.TRACKING = {

--- a/app/scripts/kano/app-modules/camera.html
+++ b/app/scripts/kano/app-modules/camera.html
@@ -17,7 +17,9 @@
             }
 
             _flash (color, length) {
-                this.api.ledring.flash(color, length);
+                if (this.api) {
+                    this.api.ledring.flash(color, length);
+                }
             }
 
             _on () {
@@ -33,22 +35,36 @@
             }
 
             _takePicture () {
-                return this.api.camera.takePicture();
+                if (this.api) {
+                    return this.api.camera.takePicture();
+                } else {
+                    return "";
+                }
             }
 
             _lastPicture () {
-                return this.api.camera.lastPicture();
+                if (this.api) {
+                    return this.api.camera.lastPicture();
+                } else {
+                    return "";
+                }
             }
 
             _getPicture (filename) {
-                return this.api.camera.getPicture(filename);
+                if (this.api) {
+                    return this.api.camera.getPicture(filename);
+                } else {
+                    return "";
+                }
             }
 
             _connect (info) {
-                this.api.connect();
-                this.api.on('connect', () => {
-                    this.api.emit('camera:init', info);
-                });
+                if (this.api) {
+                    this.api.connect();
+                    this.api.on('connect', () => {
+                        this.api.emit('camera:init', info);
+                    });
+                }
             }
 
             config (opts) {

--- a/app/scripts/kano/app-modules/dongle.html
+++ b/app/scripts/kano/app-modules/dongle.html
@@ -24,7 +24,9 @@
             }
 
             _getDeviceForPart () {
-                return this.api.getDeviceForPart.apply(this.api, arguments);
+                if (this.api) {
+                    return this.api.getDeviceForPart.apply(this.api, arguments);
+                }
             }
         }
 

--- a/app/scripts/kano/app-modules/lightboard.html
+++ b/app/scripts/kano/app-modules/lightboard.html
@@ -87,10 +87,14 @@
             /* The UI doesn't allow more than one lightboard at the minute so
              * get all connected lightboards and do the action on all of them.
              */
-            _getAllLightboards () {
-                return this.api.getAllDevices().filter((dev) => {
-                    return dev.product === 'lightboard' || dev.product === 'RPK';
-                });
+             _getAllLightboards () {
+                if (this.api) {
+                    return this.api.getAllDevices().filter((dev) => {
+                        return dev.product === 'lightboard' || dev.product === 'RPK';
+                    });
+                } else {
+                    return [];
+                }
             }
 
             paint () {

--- a/app/scripts/kano/make-apps/hardware-api.html
+++ b/app/scripts/kano/make-apps/hardware-api.html
@@ -481,6 +481,90 @@
             'RPK': Lightboard
         };
 
+        class HardwareAPIMock extends EventEmitter {
+            // Returns an already opened connection if exists, otherwise creates a new one and returns it
+            static connect (url, nativeWS) {
+                return;
+            }
+
+            /**
+             * Ask a socket the connected devices. Times out after 20 seconds
+             */
+            static getTopDevices (socket) {
+                return new Promise().resolve([]);
+            }
+
+            getDeviceById (id) {
+                return;
+            }
+
+            requestDeviceUpdate () {}
+
+            setParts (parts) {}
+
+            getAllDevices () {
+                return [];
+            }
+
+            /**
+             * Add and try to find an existing match for the device
+             */
+            addDevice (device) {}
+
+            /**
+             * Unbinds and remove a device
+             */
+            removeDevice (device) {}
+
+            /**
+             * Try to match a device to part. Notify of a new Device creation if
+             * no match was found
+             */
+            findOrCreatePartForDevice (device) {}
+
+            /**
+             * Find a part matching the device and frees it
+             */
+            unbindPartFromDevice (device) {}
+
+            /**
+             * Wipe all the bindings between parts and devices and rematch them all
+             */
+            reassignDevices () {}
+
+            debounce (id, cb, delay) {
+                if (this._debouncers[id]) {
+                    clearTimeout(this._debouncers[id]);
+                }
+                this._debouncers[id] = setTimeout(cb, delay);
+            }
+
+            getPartForDevice (deviceId) {
+                return null;
+            }
+
+            getDeviceForPart (partId) {
+                return undefined;
+            }
+
+            _getPartById (partId) {
+                return null;
+            }
+
+            /**
+             * A KitDevice will have a devices property with all its
+             * slave devices when it has finished setting up.
+             * Return true if that array is not present yet.
+             */
+            anyKitDeviceNotReady (devices) {}
+
+            _doGetAllDevices (root) {
+               return [];
+            }
+
+            tearDown () {}
+        }
+
         /**
          *  -> Has a [] of parts's models
          *  -> Receives an event when a new part is added
@@ -495,10 +579,13 @@
             constructor (config) {
                 super();
 
-                this._debouncers = {};
-
-                if (config) {
-                    this.config(config);
+                if (config.USE_HARDWARE_API) {
+                    this._debouncers = {};
+                    if (config) {
+                        this.config(config);
+                    }
+                } else {
+                    return new HardwareAPIMock();
                 }
             }
 


### PR DESCRIPTION
The idea here is that the hardware api can be turned off through the configuration property `USE_HARDWARE_API`. This is set to either `[true|false]`.

Also all calls to functions that attempt to use the api should first check that it is loaded and if not return an appropriate default value.