### PR TITLE
App URL changed to /projects page with /login when user logged in KW

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 make-apps (3.14.0-1) unstable; urgency=low
 
   * Changed the app icon which appears on the Dashboard
+  * App URL changed to /projects page with /login when user logged in KW
 
- -- Team Kano <dev@kano.me>  Mon, 27 Nov 2017 13:05:00 +0000
+ -- Team Kano <dev@kano.me>  Thu, 30 Nov 2017 17:49:00 +0000
 
 make-apps (1.1.0-1) unstable; urgency=low
 

--- a/rpi/bin/make-apps
+++ b/rpi/bin/make-apps
@@ -30,6 +30,8 @@ if __name__ == '__main__' and __package__ is None:
 import kano_i18n.init
 kano_i18n.init.install('make-apps', LOCALE_PATH)
 
+from kano_world.functions import get_token
+
 from kano_profile.tracker import Tracker
 kanotracker = Tracker()
 
@@ -150,7 +152,15 @@ kwargs = {}
 if len(sys.argv) > 1:
     kwargs['load_path'] = sys.argv[1]
 
-URL = os.getenv('URL') or "https://make-apps-kit.kano.me"
+
+token = get_token()
+
+if token:
+    URL = 'https://world.kano.me/login/{token}?redirect=projects'.format(token=token)
+else:
+    URL = 'https://world.kano.me/projects'
+
+URL = os.getenv('URL') or URL
 
 # TODO: for when Kano Code can handle the UI without a top bar
 # chromium-browser --kiosk URL


### PR DESCRIPTION
Firstly, changed the URL to go to the world.kano.me/projects page
to avoid an old redirect from the index page. Secondly, the launcher
will use the /login/ endpoint if the user logged into KW from the
kit already.