### PR TITLE
Get base Kano World URL from the config file

### DIFF
--- a/rpi/bin/make-apps
+++ b/rpi/bin/make-apps
@@ -31,6 +31,7 @@ import kano_i18n.init
 kano_i18n.init.install('make-apps', LOCALE_PATH)
 
 from kano_world.functions import get_token
+from kano_world.config import WORLD_URL
 
 from kano_profile.tracker import Tracker
 kanotracker = Tracker()
@@ -156,9 +157,9 @@ if len(sys.argv) > 1:
 token = get_token()
 
 if token:
-    URL = 'https://world.kano.me/login/{token}?redirect=projects'.format(token=token)
+    URL = '{url}/login/{token}?redirect=projects'.format(url=WORLD_URL, token=token)
 else:
-    URL = 'https://world.kano.me/projects'
+    URL = '{url}/projects'.format(url=WORLD_URL)
 
 URL = os.getenv('URL') or URL
 


### PR DESCRIPTION
This is an improvement from the last commit to be able to use the
staging environment. Effectively, this will allow the launcher to
open world-staging.kano.me or world.kano.me.