### PR TITLE
Fix old shared apps

### DIFF
--- a/app/elements/kano-workspace-normal/kano-workspace-normal.html
+++ b/app/elements/kano-workspace-normal/kano-workspace-normal.html
@@ -22,6 +22,9 @@
         <canvas id="canvas" width$="[[width]]" height$="[[height]]"></canvas>
         <div class="content">
             <slot name="part"></slot>
+            <!-- This is here for legacy apps that slot components into
+                 the workspace without a name -->
+            <slot></slot>
         </div>
     </template>
     <script>


### PR DESCRIPTION
During the Polymer 2 work, we moved to using named slots in
kano-workspace-normal. Old apps, however, slot parts to the workspace
without a name.

This commit adds a catch-all slot after the parts one where any unnamed
elements land.

cc @paulvarache @russormes