### PR TITLE
confirmShare: Show sign up instead of login

### DIFF
--- a/app/elements/behaviors/kano-sharing-behavior.html
+++ b/app/elements/behaviors/kano-sharing-behavior.html
@@ -409,7 +409,7 @@ var SharingBehavior = {
         if (!this.user) {
             // Flag the sharing as waiting authentication and trigger a login event
             this.waitingAuth = true;
-            return this.fire('login');
+            return this.fire('signup');
         }
 
         let shareOptions = { share: true };


### PR DESCRIPTION
Prompt the user to sign up rather than log in when they want to share
without an account.

Related to: https://trello.com/c/1Av0NO8k/74-when-saving-on-kano-code-prompt-sign-up-by-default-over-sign-in