### PR TITLE
Remove if collides from Code API

### DIFF
--- a/app/lib/meta-api/modules/logic.js
+++ b/app/lib/meta-api/modules/logic.js
@@ -6,6 +6,7 @@ const COLOR = '#f75846';
 class BlocklyLogic {
     static get type() { return 'blockly'; }
     static get id() { return 'logic'; }
+    static get color() { return COLOR; }
     static register(Blockly) {
         Blockly.Blocks.logic_compare = {
             init() {
@@ -38,48 +39,6 @@ class BlocklyLogic {
                 this.setHelpUrl('%{BKY_LOGIC_COMPARE_HELPURL}');
             },
         };
-
-        Blockly.Blocks.if_collides = {
-            init() {
-                Blockly.Blocks.collision_event.applyCollisionFields('', this);
-
-                this.setOutput('Boolean');
-
-                this.setColour(COLOR);
-            },
-            getFirstPartOptions() {
-                const parts = Blockly.Blocks.collision_event.getParts() || [];
-                const options = parts.map(this.formatPartOption);
-
-                if (!options.length) {
-                    options.push(['No available part', '']);
-                }
-
-                return options;
-            },
-            getSecondPartOptions() {
-                const parts = Blockly.Blocks.collision_event.getParts() || [];
-                const options = parts.filter(part => part.id !== this.getFieldValue('PART1')).map(this.formatPartOption);
-
-                // The @ here is to make sure no part id will collide with this name
-                options.push(['Top Edge', "'@top-edge'"]);
-                options.push(['Right Edge', "'@right-edge'"]);
-                options.push(['Bottom Edge', "'@bottom-edge'"]);
-                options.push(['Left Edge', "'@left-edge'"]);
-
-                return options;
-            },
-            formatPartOption(part) {
-                return [part.name, `parts.get('${part.id}')`];
-            },
-        };
-
-        Blockly.JavaScript.if_collides = (block) => {
-            const part1Id = block.getFieldValue('PART1');
-            const part2Id = block.getFieldValue('PART2');
-            const code = `parts.collisionBetween(${part1Id || null}, ${part2Id})`;
-            return [code];
-        };
         // Assign custom color to blockly core blocks
         [
             'controls_if',
@@ -102,7 +61,6 @@ class BlocklyLogic {
                 'logic_operation',
                 'logic_negate',
                 'logic_boolean',
-                'if_collides',
             ],
         };
     }

--- a/app/scripts/meta-api/all.js
+++ b/app/scripts/meta-api/all.js
@@ -1,0 +1,21 @@
+import BlocklyAssets from '../../lib/meta-api/modules/assets.js';
+import BlocklyColor from '../../lib/meta-api/modules/color.js';
+import BlocklyControl from '../../lib/meta-api/modules/control.js';
+import BlocklyEvents from '../../lib/meta-api/modules/events.js';
+import BlocklyLists from '../../lib/meta-api/modules/lists.js';
+import BlocklyLogic from './logic.js';
+import BlocklyMath from '../../lib/meta-api/modules/math.js';
+import BlocklyVariables from '../../lib/meta-api/modules/variables.js';
+
+export const AllApis = [
+    BlocklyEvents,
+    BlocklyControl,
+    BlocklyLogic,
+    BlocklyMath,
+    BlocklyVariables,
+    BlocklyColor,
+    BlocklyLists,
+    BlocklyAssets,
+];
+
+export default AllApis;

--- a/app/scripts/meta-api/logic.js
+++ b/app/scripts/meta-api/logic.js
@@ -1,0 +1,58 @@
+import BaseLogic from '../../lib/meta-api/modules/logic.js';
+
+// Logic module specific to Kano Code. Adds a collision if statement
+
+class BlocklyLogic extends BaseLogic {
+    static register(Blockly) {
+        BaseLogic.register(Blockly);
+        Blockly.Blocks.if_collides = {
+            init() {
+                Blockly.Blocks.collision_event.applyCollisionFields('', this);
+
+                this.setOutput('Boolean');
+
+                this.setColour(BaseLogic.color);
+            },
+            getFirstPartOptions() {
+                const parts = Blockly.Blocks.collision_event.getParts() || [];
+                const options = parts.map(this.formatPartOption);
+
+                if (!options.length) {
+                    options.push(['No available part', '']);
+                }
+
+                return options;
+            },
+            getSecondPartOptions() {
+                const parts = Blockly.Blocks.collision_event.getParts() || [];
+                const options = parts.filter(part => part.id !== this.getFieldValue('PART1')).map(this.formatPartOption);
+
+                // The @ here is to make sure no part id will collide with this name
+                options.push(['Top Edge', "'@top-edge'"]);
+                options.push(['Right Edge', "'@right-edge'"]);
+                options.push(['Bottom Edge', "'@bottom-edge'"]);
+                options.push(['Left Edge', "'@left-edge'"]);
+
+                return options;
+            },
+            formatPartOption(part) {
+                return [part.name, `parts.get('${part.id}')`];
+            },
+        };
+
+        Blockly.JavaScript.if_collides = (block) => {
+            const part1Id = block.getFieldValue('PART1');
+            const part2Id = block.getFieldValue('PART2');
+            const code = `parts.collisionBetween(${part1Id || null}, ${part2Id})`;
+            return [code];
+        };
+    }
+    static get category() {
+        const baseCategory = Object.assign({}, BaseLogic.category);
+        baseCategory.blocks = baseCategory.blocks.slice(0);
+        baseCategory.blocks.push('if_collides');
+        return baseCategory;
+    }
+}
+
+export default BlocklyLogic;

--- a/app/views/kano-view-editor/kano-view-editor.js
+++ b/app/views/kano-view-editor/kano-view-editor.js
@@ -12,7 +12,7 @@ import '../../elements/kc-file-upload-overlay/kc-file-upload-overlay.js';
 import { AllModules } from '../../lib/app-modules/all.js';
 import { ChallengeGeneratorPlugin } from '../../lib/challenge/index.js';
 import { Editor, FileUploadPlugin, I18n, LocalStoragePlugin, Mode, PartsPlugin, Runner, UserPlugin } from '../../lib/index.js';
-import { AllApis } from '../../lib/meta-api/modules/all.js';
+import { AllApis } from '../../scripts/meta-api/all.js';
 import '../../scripts/kano/make-apps/actions/app.js';
 import '../../scripts/kano/make-apps/blockly/blockly.js';
 import { SDK } from '../../scripts/kano/make-apps/sdk.js';

--- a/app/views/kano-view-story/kano-view-story.js
+++ b/app/views/kano-view-story/kano-view-story.js
@@ -3,6 +3,9 @@ import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '@kano/web-components/kano-reward-modal/kano-reward-modal.js';
 import '@kano/web-components/kano-alert/kano-alert.js';
+import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { SoundPlayerBehavior } from '@kano/web-components/kano-sound-player-behavior/kano-sound-player-behavior.js';
 import '../../elements/kano-app-challenge/kano-app-challenge.js';
 import '../../elements/kano-app-editor/kano-app-editor.js';
@@ -20,13 +23,10 @@ import '../../scripts/kano/make-apps/actions/app.js';
 import { Utils } from '../../scripts/kano/make-apps/utils.js';
 import { experiments } from '../../scripts/kano/make-apps/experiments.js';
 import { ViewBehavior } from '../../elements/behaviors/kano-view-behavior.js';
-import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
-import { html } from '@polymer/polymer/lib/utils/html-tag.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { Editor, UserPlugin, PartsPlugin, Runner, Mode } from '../../lib/index.js';
 import { PartTypes, Parts } from '../../lib/parts/all.js';
 import { AllModules } from '../../lib/app-modules/all.js';
-import { AllApis } from '../../lib/meta-api/modules/all.js';
+import { AllApis } from '../../scripts/meta-api/all.js';
 import { Challenge } from '../../lib/challenge/index.js';
 
 const behaviors = [


### PR DESCRIPTION
 - Remove if_collides block from the logic module in the Kano Code Engine
 - Move the block to a custom logic module specific to the Kano Code website