### PR TITLE
Add updated challenge generator

### DIFF
--- a/app/lib/challenge/generator/api.js
+++ b/app/lib/challenge/generator/api.js
@@ -1,37 +1,113 @@
-export const GeneratorAPIProvider = (editor) => {
-    return {
-        type: 'module',
-        name: 'generator',
-        verbose: 'Challenge',
-        color: '#676767',
-        symbols: [{
-            type: 'function',
-            name: 'banner',
-            parameters: [{
-                name: 'text',
-                default: "'Banner content'",
-                returnType: String,
-                blockly: {
-                    field: true,
-                },
-            }],
+function TextareaFieldProvider(Blockly) {
+    return class extends Blockly.FieldTextInput {
+        constructor(text) {
+            super(text, (nextValue) => {
+                try {
+                    JSON.parse(nextValue);
+                } catch (e) {
+                    return null;
+                }
+            });
+        }
+        showEditor_() {
+            this.workspace_ = this.sourceBlock_.workspace;
+            Blockly.WidgetDiv.show(this, this.sourceBlock_.RTL, this.widgetDispose_());
+            const div = Blockly.WidgetDiv.DIV;
+            // Create the input.
+            const htmlInput =
+                goog.dom.createDom(goog.dom.TagName.TEXTAREA, 'blocklyHtmlInput');
+            htmlInput.style.width = '300px';
+            htmlInput.style.height = '200px';
+            htmlInput.setAttribute('spellcheck', this.spellcheck_);
+            const fontSize =
+                `${Blockly.FieldTextInput.FONTSIZE * this.workspace_.scale}pt`;
+            div.style.fontSize = fontSize;
+            htmlInput.style.fontSize = fontSize;
+
+            Blockly.FieldTextInput.htmlInput_ = htmlInput;
+            div.appendChild(htmlInput);
+
+            htmlInput.value = htmlInput.defaultValue = this.text_;
+            htmlInput.oldValue_ = null;
+            this.validate_();
+            this.resizeEditor_();
+            htmlInput.focus();
+            htmlInput.select();
+            this.bindEvents_(htmlInput);
+        }
+        onHtmlInputKeyDown_(e) {
+            const htmlInput = Blockly.FieldTextInput.htmlInput_;
+            const escKey = 27;
+            const tabKey = 9;
+            if (e.keyCode == escKey) {
+                htmlInput.value = htmlInput.defaultValue;
+                Blockly.WidgetDiv.hide();
+            } else if (e.keyCode == tabKey) {
+                const cIndex = htmlInput.selectionStart;
+                htmlInput.value = [htmlInput.value.slice(0, cIndex), // Slice at cursor index
+                    '    ', // Add Tab
+                    htmlInput.value.slice(cIndex)].join('');// Join with the end
+                e.stopPropagation();
+                e.preventDefault(); // Don't quit the area
+                htmlInput.selectionStart = cIndex + 4;
+                htmlInput.selectionEnd = cIndex + 4;
+            }
+        }
+    };
+}
+
+export const GeneratorAPIProvider = editor => ({
+    type: 'module',
+    name: 'generator',
+    verbose: 'Challenge',
+    color: '#676767',
+    symbols: [{
+        type: 'function',
+        name: 'banner',
+        parameters: [{
+            name: 'text',
+            default: "'Banner content'",
+            returnType: String,
             blockly: {
-                javascript(Blockly, block) {
-                    const bannerText = block.getFieldValue('TEXT');
-                    return `// @banner: ${bannerText}\n`;
-                },
+                field: true,
             },
-        }, {
-            type: 'function',
-            name: 'start',
+        }],
+        blockly: {
+            javascript(Blockly, block) {
+                const bannerText = block.getFieldValue('TEXT');
+                return `// @banner: ${bannerText}\n`;
+            },
+        },
+    }, {
+        type: 'function',
+        name: 'start',
+        blockly: {
+            javascript(Blockly) {
+                return '// @challenge-start\n';
+            },
+        },
+    }, {
+        type: 'function',
+        name: 'step',
+        parameters: [{
+            name: 'json',
+            returnType: String,
             blockly: {
-                javascript(Blockly) {
-                    return '// @challenge-start\n';
+                customField(Blockly) {
+                    const TextareaField = TextareaFieldProvider(Blockly);
+                    return new TextareaField(`{
+    
+}`);
                 },
             },
         }],
-    };
-};
+        blockly: {
+            javascript(Blockly) {
+                return '// @step\n';
+            },
+        },
+    }],
+});
 
 export default GeneratorAPIProvider;
 

--- a/app/lib/meta-api/renderer/blockly.js
+++ b/app/lib/meta-api/renderer/blockly.js
@@ -241,20 +241,19 @@ class BlocklyMetaRenderer {
         case String:
         default: {
             if (param.def.blockly && param.def.blockly.field) {
-                let t;
                 switch (type) {
                 case Number:
-                    t = 'field_number';
-                    break;
+                    return {
+                        type: 'field_number',
+                        value: param.def.default,
+                    };
                 case String:
                 default:
-                    t = 'field_input';
-                    break;
+                    return {
+                        type: 'field_input',
+                        text: param.def.default,
+                    };
                 }
-                return {
-                    type: t,
-                    value: param.def.default,
-                };
             }
             return {
                 type: 'input_value',


### PR DESCRIPTION
 - Removed default blocks matching. Generator start block replaces this
 - Updated blockly meta api renderer to load the default value of text fields
 - Added simple json texarea field for steps definition
 - Added Generator step block that allows to inject a step into a challenge
 - Ensures challenges are generated even if Generator blocks don't have a next block connected to them
 - Allows multiple entry points in blocks tree to be generated. Will scan the top level blocks for start blocks and generate the preloaded tree of blocks in the defaultApp. Will process all other blocks as blocks to be created by the user during the challenge