### PR TITLE
Only read direct child comment node for challenge generation

### DIFF
--- a/app/lib/challenge/generator/index.js
+++ b/app/lib/challenge/generator/index.js
@@ -363,14 +363,16 @@ class Challenge extends Plugin {
         return [JSON.parse(jsonString)];
     }
     parseComment(node) {
-        const commentNode = node.getElementsByTagName('comment')[0];
         let data = {};
-        if (commentNode) {
-            try {
-                data = JSON.parse(commentNode.innerText);
-            } catch (e) {
-                this.editor.logger.warn(`Could not parse comment '${commentNode.innerText}'`);
-            }
+        const commentNode = node.querySelector('comment');
+        // No comment found or comment node is not direct child of node
+        if (!commentNode || commentNode.parentNode !== node) {
+            return data;
+        }
+        try {
+            data = JSON.parse(commentNode.innerText);
+        } catch (e) {
+            this.editor.logger.warn(`Could not parse comment '${commentNode.innerText}'`);
         }
         return data;
     }

--- a/tasks/named-resolution-middleware.js
+++ b/tasks/named-resolution-middleware.js
@@ -32,7 +32,7 @@ module.exports = (opts = {}) => {
         const decoder = new StringDecoder('utf-8');
 
         function sendData() {
-            if (!queue.length) {
+            if (!queue || !queue.length) {
                 return _end.call(res);
             }
             if (_write.call(res, queue.shift())) {


### PR DESCRIPTION
 - Fixes an issue where any comment in the XML tree was used to generate challenge copy instead of direct child of the block node.
 - Fixes an issue with the server middleware