### PR TITLE
Use editor api to restart code from block

### DIFF
--- a/app/lib/app-modules/global.js
+++ b/app/lib/app-modules/global.js
@@ -1,8 +1,8 @@
 import AppModule from './app-module.js';
 
 class GlobalModule extends AppModule {
-    constructor() {
-        super();
+    constructor(editorOrPlayer) {
+        super(editorOrPlayer);
         this.addMethod('when', '_when');
         this.addMethod('emit', '_emit');
         this.addMethod('restartCode', '_restartCode');
@@ -12,10 +12,6 @@ class GlobalModule extends AppModule {
     }
 
     static get name() { return 'global'; }
-
-    config(opts) {
-        this._restartCodeHandler = opts.restartCodeHandler;
-    }
 
     _when(name, callback) {
         this._listeners[name] = this._listeners[name] || [];
@@ -41,9 +37,7 @@ class GlobalModule extends AppModule {
     }
 
     _restartCode() {
-        if (this._restartCodeHandler) {
-            this._restartCodeHandler();
-        }
+        this.editor.restartApp();
     }
 
     _afterRun() {


### PR DESCRIPTION
 - Remove configuration of the restartHandler from config. Use the editor API to restart runner. In a close future, the module will receive a `editorOrPlayer` instance that will implement `restartApp` to support an app running in the editor or a player