### PR TITLE
Renaming AppModule.name to .id

### DIFF
--- a/app/lib/app-modules/app-modules.js
+++ b/app/lib/app-modules/app-modules.js
@@ -4,18 +4,18 @@ class AppModules {
         this.output = output;
         this.modules = {};
     }
-    define(name, ModuleClass) {
-        this.modules[name] = new ModuleClass(this.output);
+    define(id, ModuleClass) {
+        this.modules[id] = new ModuleClass(this.output);
         if (ModuleClass.aliases) {
             ModuleClass.aliases.forEach((alias) => {
-                this.modules[alias] = this.modules[name];
+                this.modules[alias] = this.modules[id];
             });
         }
     }
     config(config) {
-        Object.keys(this.modules).forEach((name) => {
-            if (this.modules[name] && this.modules[name].config && typeof this.modules[name].config === 'function') {
-                this.modules[name].config(config);
+        Object.keys(this.modules).forEach((id) => {
+            if (this.modules[id] && this.modules[id].config && typeof this.modules[id].config === 'function') {
+                this.modules[id].config(config);
             }
         });
     }
@@ -25,25 +25,25 @@ class AppModules {
     init(...args) {
         this.config(...args);
     }
-    getModule(name) {
-        if (this.modules[name]) {
-            return this.modules[name].methods;
+    getModule(id) {
+        if (this.modules[id]) {
+            return this.modules[id].methods;
         }
         return {};
     }
     createAppCode(prefix, code) {
-        const moduleImports = Object.keys(this.modules).reduce((acc, name) => {
-            const symbols = this.modules[name].getSymbols();
-            acc += `var ${name} = ${prefix}.getModule('${name}');\n`;
-            acc += symbols.map(s => `var ${s} = ${prefix}.getModule('${name}').${s};\n`).join('');
+        const moduleImports = Object.keys(this.modules).reduce((acc, id) => {
+            const symbols = this.modules[id].getSymbols();
+            acc += `var ${id} = ${prefix}.getModule('${id}');\n`;
+            acc += symbols.map(s => `var ${s} = ${prefix}.getModule('${id}').${s};\n`).join('');
             return acc;
         }, '');
         return `(function () {\n${moduleImports}\n${code}\n})();\n`;
     }
     _runModuleLifecycleStep(name) {
-        Object.keys(this.modules).forEach((key) => {
-            if (typeof this.modules[key].executeLifecycleStep === 'function') {
-                this.modules[key].executeLifecycleStep(name);
+        Object.keys(this.modules).forEach((id) => {
+            if (typeof this.modules[id].executeLifecycleStep === 'function') {
+                this.modules[id].executeLifecycleStep(name);
             }
         });
     }

--- a/app/lib/app-modules/camera.js
+++ b/app/lib/app-modules/camera.js
@@ -14,7 +14,7 @@ class CameraModule extends AppModule {
         this.addMethod('connect', '_connect');
     }
 
-    static get name() { return 'camera'; }
+    static get id() { return 'camera'; }
 
     _flash(color, length) {
         if (this.api) {

--- a/app/lib/app-modules/colour.js
+++ b/app/lib/app-modules/colour.js
@@ -9,7 +9,7 @@ class ColourModule extends AppModule {
         this.addMethod('lerp', '_lerp');
     }
 
-    static get name() { return 'colour'; }
+    static get id() { return 'colour'; }
 
     HSVtoRGB(h, s, v) {
         let r;

--- a/app/lib/app-modules/data.js
+++ b/app/lib/app-modules/data.js
@@ -120,7 +120,7 @@ class DataModule extends AppModule {
         this.addMethod('clock', '_clock');
     }
 
-    static get name() { return 'data'; }
+    static get id() { return 'data'; }
 
     config(c) {
         super.config(c);
@@ -214,12 +214,12 @@ class DataModule extends AppModule {
             if (this.cache[url].response) {
                 // Returns a cloned version of the response
                 return Promise.resolve(this.cache[url].response.clone());
-            } 
+            }
                 // Wait for the request to finish before returning the response
                 return this.cache[url].finished.then(() => {
                     return this.cache[url].response.clone()
                 }).catch(e => {});
-            
+
         }
     }
 

--- a/app/lib/app-modules/date.js
+++ b/app/lib/app-modules/date.js
@@ -9,7 +9,7 @@ class DateModule extends AppModule {
         this.addMethod('getFormattedTime', '_getFormattedTime');
     }
 
-    static get name() { return 'date'; }
+    static get id() { return 'date'; }
 
     _getCurrent() {
         let current = {},

--- a/app/lib/app-modules/draw.js
+++ b/app/lib/app-modules/draw.js
@@ -7,7 +7,7 @@ export const DrawModuleFactory = (provider) => {
             super(output);
             this.addLifecycleStep('start', '_start');
         }
-        static get name() {
+        static get id() {
             return 'ctx';
         }
         _start() {

--- a/app/lib/app-modules/factory/assets.js
+++ b/app/lib/app-modules/factory/assets.js
@@ -8,7 +8,7 @@ export const AssetsModuleFactory = (assetsRoot, stickers) => class AssetsModule 
         this.addMethod('randomSticker', '_randomSticker');
     }
 
-    static get name() {
+    static get id() {
         return 'assets';
     }
 

--- a/app/lib/app-modules/global.js
+++ b/app/lib/app-modules/global.js
@@ -11,7 +11,7 @@ class GlobalModule extends AppModule {
         this._reset();
     }
 
-    static get name() { return 'global'; }
+    static get id() { return 'global'; }
 
     _when(name, callback) {
         this._listeners[name] = this._listeners[name] || [];

--- a/app/lib/app-modules/index.js
+++ b/app/lib/app-modules/index.js
@@ -9,7 +9,7 @@ class AppModulesLoader {
     start() {
         this.appModules.init(this.output.config);
         this.modules.forEach((Mod) => {
-            this.appModules.define(Mod.name, Mod);
+            this.appModules.define(Mod.id, Mod);
         });
     }
 }

--- a/app/lib/app-modules/lightboard.js
+++ b/app/lib/app-modules/lightboard.js
@@ -31,7 +31,7 @@ class LightboardModule extends AppModule {
         this.addMethod('clear', '_clear');
     }
 
-    static get name() { return 'lightboard'; }
+    static get id() { return 'lightboard'; }
 
     config(opts) {
         this.api = opts.hardwareAPI;
@@ -95,9 +95,9 @@ class LightboardModule extends AppModule {
             return this.api.getAllDevices().filter((dev) => {
                 return dev.product === 'lightboard' || dev.product === 'RPK';
             });
-        } 
+        }
             return [];
-        
+
     }
 
     paint() {

--- a/app/lib/app-modules/loop.js
+++ b/app/lib/app-modules/loop.js
@@ -10,7 +10,7 @@ class LoopModule extends AppModule {
         this.addLifecycleStep('stop', '_stop');
     }
 
-    static get name() { return 'loop'; }
+    static get id() { return 'loop'; }
 
     _forever(callback) {
         // push the next tick to the end of the events queue

--- a/app/lib/app-modules/loops.js
+++ b/app/lib/app-modules/loops.js
@@ -1,7 +1,7 @@
 import LoopModule from './loop.js';
 
 class LoopsModule extends LoopModule {
-    static get name() { return 'loops'; }
+    static get id() { return 'loops'; }
 }
 
 export default LoopsModule;

--- a/app/lib/app-modules/math.js
+++ b/app/lib/app-modules/math.js
@@ -8,7 +8,7 @@ class MathModule extends AppModule {
         this.addMethod('sign', '_sign');
         this.addMethod('lerp', '_lerp');
     }
-    static get name() { return 'math'; }
+    static get id() { return 'math'; }
     _sign(x) {
         x = +x; // convert to a number
         if (x === 0 || isNaN(x)) {

--- a/app/lib/app-modules/mic.js
+++ b/app/lib/app-modules/mic.js
@@ -13,7 +13,7 @@ class MicModule extends AppModule {
         this.addMethod('getPitch', '_getPitch');
     }
 
-    static get name() { return 'mic'; }
+    static get id() { return 'mic'; }
 
     _getAudioStream() {
         if (this.api) {

--- a/app/lib/app-modules/motion.js
+++ b/app/lib/app-modules/motion.js
@@ -1,7 +1,7 @@
 import DongleModule from './dongle.js';
 
 class MotionModule extends DongleModule {
-    static get name() { return 'motionSensor'; }
+    static get id() { return 'motionSensor'; }
 }
 
 export default MotionModule;

--- a/app/lib/app-modules/parts.js
+++ b/app/lib/app-modules/parts.js
@@ -13,7 +13,7 @@ class PartsModule extends AppModule {
         };
     }
 
-    static get name() { return 'parts'; }
+    static get id() { return 'parts'; }
 
     static get aliases() { return ['devices']; }
 
@@ -68,7 +68,7 @@ class PartsModule extends AppModule {
     }
 
     _whenCollision(part1, part2, callback) {
-        let part1Id, 
+        let part1Id,
             part2Id;
         if (!part1 || !part2) {
             return;
@@ -91,7 +91,7 @@ class PartsModule extends AppModule {
     }
 
     _collides(part1, part2) {
-        let collides, 
+        let collides,
 part1Rect;
         if (!part1 || !part2) {
             return;

--- a/app/lib/app-modules/tilt.js
+++ b/app/lib/app-modules/tilt.js
@@ -1,7 +1,7 @@
 import DongleModule from './dongle.js';
 
 class TiltModule extends DongleModule {
-    static get name() { return 'gyroAccelerometer'; }
+    static get id() { return 'gyroAccelerometer'; }
 }
 
 export default TiltModule;

--- a/app/lib/app-modules/time.js
+++ b/app/lib/app-modules/time.js
@@ -15,7 +15,7 @@ class TimeModule extends AppModule {
         this.addLifecycleStep('stop', '_stop');
     }
 
-    static get name() { return 'time'; }
+    static get id() { return 'time'; }
 
     getId() {
         return this.incr++;
@@ -25,8 +25,8 @@ class TimeModule extends AppModule {
         if (unit === 'frames') {
             let loopId = this.getId(),
                 startTimestamp,
-                func, 
-                dt, 
+                func,
+                dt,
                 diff;
             // Round and min to 1
             interval = Math.max(1, Math.round(interval));

--- a/app/lib/output/module.js
+++ b/app/lib/output/module.js
@@ -6,6 +6,11 @@ export class OutputModule extends AppModule {
         this.addLifecycleStep('start', '_start');
         this.addLifecycleStep('stop', '_stop');
     }
+
+    static get id() {
+        return 'output';
+    }
+
     _start() {
         if (!this.output.outputView) {
             return;


### PR DESCRIPTION
This is because Safari was overriding it with a class name.