### PR TITLE
Update ActivityBar API

### DIFF
--- a/app/elements/kano-app-editor/kano-app-editor.js
+++ b/app/elements/kano-app-editor/kano-app-editor.js
@@ -243,15 +243,21 @@ class KanoAppEditor extends Store.StateReceiver(mixinBehaviors([
                 display: flex;
                 flex-direction: column;
             }
-            .activity-bar > * {
+            .activity-bar > button {
                 display: inline-flex;
                 justify-content: center;
                 align-items: center;
                 margin: 0;
                 width: 48px;
                 height: 40px;
+                background: transparent;
+                border: none;
+                padding: 0px;
             }
-            .activity-bar > *:not([disabled]) {
+            .activity-bar > button:first-of-type {
+                height: 44px;
+            }
+            .activity-bar > button:not([disabled]) {
                 cursor: pointer;
             }
             .activity-bar button {
@@ -259,13 +265,19 @@ class KanoAppEditor extends Store.StateReceiver(mixinBehaviors([
                 border: none;
                 padding: 0px;
             }
+            .activity-bar button:focus img {
+                opacity: 1;
+            }
             .activity-bar button:focus {
                 outline: none;
             }
             .activity-bar button img {
-                margin: 8px 8px 0 8px;
+                margin: 4px 8px 4px 8px;
                 width: 32px;
                 height: 32px;
+            }
+            .activity-bar button:first-of-type img {
+                margin-top: 8px
             }
             .activity-bar button img {
                 transition: opacity 0.15s ease;

--- a/app/elements/kano-tooltip/kano-tooltip.js
+++ b/app/elements/kano-tooltip/kano-tooltip.js
@@ -199,7 +199,7 @@ class KanoTooltip extends PolymerElement {
         let target = e.path ? e.path[0] : e.target;
         if (this.autoClose && this.opened) {
             // Go up the dom to check if the event originated from inside the tooltip or not
-            while (target !== this && target !== document.body) {
+            while (target !== this && target !== document.body && target.parentNode) {
                 target = target.parentNode || target.host;
             }
             if (target !== this) {
@@ -277,6 +277,7 @@ class KanoTooltip extends PolymerElement {
                 this.$.tooltip.classList.remove('pop-in');
                 this.$.tooltip.removeEventListener('animationend', onAnimationEnd);
             };
+            this.$.tooltip.style.transformOrigin = this._getTransformOrigin();
             this.$.tooltip.addEventListener('animationend', onAnimationEnd);
             this.$.tooltip.classList.add('pop-in');
 
@@ -293,8 +294,23 @@ class KanoTooltip extends PolymerElement {
             this.style.visibility = 'hidden';
             this.$.tooltip.removeEventListener('animationend', onAnimationEnd);
         };
+        this.$.tooltip.style.transformOrigin = this._getTransformOrigin();
         this.$.tooltip.addEventListener('animationend', onAnimationEnd);
         this.$.tooltip.classList.add('pop-out');
+    }
+    _getTransformOrigin() {
+        switch (this.position) {
+        case 'top':
+            return '50% 100%';
+        case 'right':
+            return '0 50%';
+        case 'bottom':
+            return '50% 0%';
+        case 'left':
+            return '100% 50%';
+        default:
+            return '0 50%';
+        }
     }
     setupTargetTracking() {
         const { target } = this;

--- a/docs/editor/activity-bar.md
+++ b/docs/editor/activity-bar.md
@@ -16,7 +16,7 @@ const activityBarEntry = editor.activityBar.registerEntry({
 });
 
 // Triggered on click/touch
-activityBarEntry.on('activate', () => {});
+activityBarEntry.onDidActivate(() => {});
 
 // Update the disabled status of the entry
 activityBarEntry.disable();
@@ -24,4 +24,16 @@ activityBarEntry.enable();
 
 // Remove the entry
 activityBarEntry.dispose();
+```
+
+You can also add an entry that will display a tooltip on click/tap:
+
+```js
+editor.activityBar.registerTooltipEntry({
+    title: 'Hello',
+    icon: '/assets/icons/info.svg',
+    disabled: false,
+    root: document.createElement('button'),
+    offset: 20,
+});
 ```

--- a/examples/plugins/profile.js
+++ b/examples/plugins/profile.js
@@ -184,6 +184,7 @@ export class SpiralWorkspaceViewProvider extends code.WorkspaceViewProvider {
             <div id="tools">
                 <button id="alert">Display Alert</button>
                 <button id="activity-bar">Add ActivityBar entry</button>
+                <button id="activity-bar-tooltip">Add ActivityBar tooltip entry</button>
                 <button id="creation">Show creation</button>
             </div>
         `;
@@ -221,8 +222,20 @@ export class SpiralWorkspaceViewProvider extends code.WorkspaceViewProvider {
                 icon: './assets/code.png',
             });
             // Remove the entry when it is clicked
-            entry.on('activate', () => {
+            entry.onDidActivate(() => {
                 entry.dispose();
+            });
+        });
+        const activityBarTooltipEntryButton = this._root.querySelector('#activity-bar-tooltip');
+        activityBarTooltipEntryButton.addEventListener('click', () => {
+            const root = document.createElement('div');
+            root.style.padding = '16px';
+            root.innerText = 'Tooltip';
+            this.editor.activityBar.registerTooltipEntry({
+                title: 'Custom Entry',
+                icon: './assets/code.png',
+                root,
+                offset: Math.random() * 20,
             });
         });
     }

--- a/tests/unit/editor/activity-bar.test.js
+++ b/tests/unit/editor/activity-bar.test.js
@@ -32,7 +32,7 @@ suite('Editor', () => {
                 title,
                 icon,
             });
-            entry.on('activate', () => {
+            entry.onDidActivate(() => {
                 done();
             });
             click(entry.root);
@@ -47,6 +47,19 @@ suite('Editor', () => {
             assert(barDom.firstChild === entry.root);
             entry.dispose();
             assert(barDom.firstChild !== entry.root);
+        });
+        test('adds a tooltip entry when registered', () => {
+            const title = 'test-title';
+            const icon = '/icons/test-icon.svg';
+            const root = document.createElement('div');
+            editor.activityBar.registerTooltipEntry({
+                title,
+                icon,
+                root,
+            });
+            const tooltip = barDom.firstChild;
+            assert(tooltip.tagName.toLowerCase() === 'kano-tooltip', 'tooltip was not added to the bar');
+            assert(tooltip.firstChild === root, 'Root was not added to the tooltip');
         });
         teardown(() => {
             editor.dispose();


### PR DESCRIPTION
 - Add `registerTooltipEntry` to the activityBar API
 - Use web-common EventEmitter for entry activation event
 - Update tests and docs