### PR TITLE
Making the import and export buttons configurable

### DIFF
--- a/app/elements/kc-workspace-toolbar/kc-workspace-toolbar.js
+++ b/app/elements/kc-workspace-toolbar/kc-workspace-toolbar.js
@@ -226,14 +226,6 @@ class KCWorkspaceToolbar extends I18nMixin(PolymerElement) {
             title: this.localize('RESET_WORKSPACE', 'Reset Workspace'),
             ironIcon: 'kc-ui:reset',
         }).on('activate', () => this._reset());
-        this.addSettingsEntry({
-            title: this.localize('EXPORT', 'Export'),
-            ironIcon: 'kc-ui:export',
-        }).on('activate', () => this._export());
-        this.addSettingsEntry({
-            title: this.localize('IMPORT', 'Import'),
-            ironIcon: 'kc-ui:import',
-        }).on('activate', () => this._load());
         this.addEntry({
             id: 'restart',
             position: ToolbarEntryPosition.RIGHT,
@@ -352,12 +344,6 @@ class KCWorkspaceToolbar extends I18nMixin(PolymerElement) {
     }
     _reset() {
         this.dispatchEvent(new CustomEvent('reset-clicked'));
-    }
-    _export() {
-        this.dispatchEvent(new CustomEvent('export-clicked'));
-    }
-    _load() {
-        this.dispatchEvent(new CustomEvent('import-clicked'));
     }
     _save() {
         this.dispatchEvent(new CustomEvent('save-clicked'));

--- a/app/lib/editor/workspace/toolbar.js
+++ b/app/lib/editor/workspace/toolbar.js
@@ -10,6 +10,8 @@ export class WorkspaceToolbar extends Plugin {
         super();
         this.subscriptions = new Subscriptions();
         this._telemetry = new TelemetryClient({ scope: 'workspace_toolbar' });
+
+        this.enableImportExport = true;
     }
     /**
      * @param {Editor} editor The editor this plugin is attached to
@@ -26,6 +28,18 @@ export class WorkspaceToolbar extends Plugin {
             return;
         }
 
+        if (this.enableImportExport) {
+            this.exportButton = this.toolbar.addSettingsEntry({
+                title: this.toolbar.localize('EXPORT', 'Export'),
+                ironIcon: 'kc-ui:export',
+            }).on('activate', () => this.export());
+
+            this.importButton = this.addSettingsEntry({
+                title: this.toolbar.localize('IMPORT', 'Import'),
+                ironIcon: 'kc-ui:import',
+            }).on('activate', () => this.import());
+        }
+
         this.subscriptions.push(
             subscribe(this.editor.output, 'running-state-changed', this.updateRunningState.bind(this)),
             subscribe(this.editor.output, 'fullscreen-changed', this.updateFullscreen.bind(this)),
@@ -33,8 +47,6 @@ export class WorkspaceToolbar extends Plugin {
             subscribe(this.toolbar, 'run-clicked', this.toggleRun.bind(this)),
             subscribe(this.toolbar, 'fullscreen-clicked', this.toggleFullscreen.bind(this)),
             subscribe(this.toolbar, 'reset-clicked', this.reset.bind(this)),
-            subscribe(this.toolbar, 'export-clicked', this.export.bind(this)),
-            subscribe(this.toolbar, 'import-clicked', this.import.bind(this)),
         );
     }
     updateRunningState() {


### PR DESCRIPTION
Added a flag that allows turning off import/export buttons before editor injection.

@paulvarache Wanted to do it using `.dispose()` as you suggested but it seems that that would create a race because we can only add the buttons into the toolbar once the component has been initalised after injecting the editor.

This way though the option remains localised. And we can set it in the profile's `onInstall`.