### PR TITLE
Fixed issue with blank overlay in iOS 10.3

### DIFF
--- a/app/elements/kc-workspace-frame/kc-workspace-frame.js
+++ b/app/elements/kc-workspace-frame/kc-workspace-frame.js
@@ -67,9 +67,6 @@ Polymer({
                 @apply --layout-flex-auto;
                 box-sizing: border-box;
             }
-            :host(:not(.fullscreen)) .overlay {
-                display: none;
-            }
             .overlay {
                 position: fixed;
                 top: 0;
@@ -153,7 +150,7 @@ Polymer({
             </kc-workspace-toolbar>
             <slot name="controls"></slot>
         </div>
-        <div class="overlay">
+        <div class="overlay" hidden$="[[!fullscreen]]">
             <button id="fullscreen-close" on-tap="_toggleFullscreen">
                 <iron-icon icon="kc-ui:close"></iron-icon>
             </button>


### PR DESCRIPTION
I found a problem with empty overlay(hold control buttons) in editor's fullscreen mode in iOS 10.3. Problem was in pseudo selector `:not` on :host element. I replaced it by `hidden` property on `overlay` element. 