### PR TITLE
SX-821 bug fix: resize backdrop on disposing of a dialog

### DIFF
--- a/src/app/lib/editor/dialogs/base.ts
+++ b/src/app/lib/editor/dialogs/base.ts
@@ -69,6 +69,7 @@ export abstract class Base<T extends DialogElement> {
         if (this.root.parentNode) {
             this.root.parentNode.removeChild(this.root);
         }
+        this.resetBackdropSizing();
     }
 }
 


### PR DESCRIPTION
SX-821 will also need a fix in kit-app-ui (https://github.com/KanoComputing/kit-app-ui/pull/914) to ensure dispose() is called on the dialog when the code editor is closed.