### PR TITLE
SX-1134 SX-1136 SX-1135 3 fixes for the ch gen

### DIFF
--- a/examples/creator/index.js
+++ b/examples/creator/index.js
@@ -5,10 +5,54 @@ import '../../source-editor/blockly/creator.contribution.js';
 
 const lang = i18n.getLang();
 
+const customMod = {
+    type: 'module',
+    name: 'coord',
+    verbose: 'Coord',
+    symbols: [{
+        type: 'function',
+        name: 'point',
+        parameters: [{
+            name: 'x',
+            default: 0,
+            returnType: Number,
+        }, {
+            name: 'y',
+            default: 0,
+            returnType: Number,
+        }],
+        returnType: 'Point', 
+    }, {
+        type: 'function',
+        name: '2dMatrix',
+        parameters: [{
+            name: '1',
+            returnType: 'Point',
+            default: {},
+            blockly: {
+                shadow() {
+                    return `<shadow type="coord_point"><value name="X"><shadow type="math_number"><value name="NUM">0</value></shadow></value><value name="Y"><shadow type="math_number"><value name="NUM">0</value></shadow></value></shadow>`;
+                },
+            },
+        }, {
+            name: '2',
+            returnType: 'Point',
+            default: {},
+            blockly: {
+                shadow() {
+                    return `<shadow type="coord_point"><value name="X"><shadow type="math_number"><value name="NUM">0</value></shadow></value><value name="Y"><shadow type="math_number"><value name="NUM">0</value></shadow></value></shadow>`;
+                },
+            },
+        }],
+    }],
+}
+
 i18n.load(lang, { blockly: true, kanoCodePath: '/' })
     .then(() => {
         const editor = new code.Editor({ sourceType: 'blockly' });
         const cr = creator.create(editor);
+
+        editor.toolbox.addEntry(customMod);
 
         editor.inject(document.body);
     });

--- a/src/app/lib/modules/stamp/api.ts
+++ b/src/app/lib/modules/stamp/api.ts
@@ -3,8 +3,7 @@ import { Block } from '@kano/kwc-blockly/blockly.js';
 import { StampsField } from '../../blockly/fields/stamps-field.js';
 import { defaultStamp, stamps } from './data.js';
 import { resolve } from '../../util/image-stamp.js';
-import { _ } from '../../i18n/index.js';
-
+import { random, randomFrom } from './common.js';
 
 const getImage : IMetaDefinition = {
     type: 'function',
@@ -37,27 +36,6 @@ const getImage : IMetaDefinition = {
         },
     }
 };
-
-export const random : IMetaDefinition = {
-    type: 'function', 
-    name: 'random',
-    verbose: _('PART_STICKER_RANDOM', 'random'),
-    returnType: 'Sticker'
-};
-
-export const randomFrom : IMetaDefinition = {
-    type: 'function',
-    name: 'randomFrom',
-    verbose: _('PART_STICKER_RANDOM_FROM', 'random'),
-    returnType: 'Sticker',
-    parameters: [{
-        type: 'parameter',
-        name: 'set',
-        verbose: '',
-        returnType: 'Enum',
-        enum: stamps.map<[string, string]>(stamp => [stamp.label, stamp.id]),
-    }]
-}
 
 function hideBlock(block : IMetaDefinition) {
     const newBlock = Object.assign({}, block);

--- a/src/app/lib/modules/stamp/common.ts
+++ b/src/app/lib/modules/stamp/common.ts
@@ -1,0 +1,23 @@
+import { IMetaDefinition } from '../../meta-api/module.js';
+import { stamps } from './data.js';
+import { _ } from '../../i18n/index.js';
+
+export const random: IMetaDefinition = {
+    type: 'function',
+    name: 'random',
+    verbose: _('PART_STICKER_RANDOM', 'random'),
+    returnType: 'Sticker'
+};
+export const randomFrom: IMetaDefinition = {
+    type: 'function',
+    name: 'randomFrom',
+    verbose: _('PART_STICKER_RANDOM_FROM', 'random'),
+    returnType: 'Sticker',
+    parameters: [{
+        type: 'parameter',
+        name: 'set',
+        verbose: '',
+        returnType: 'Enum',
+        enum: stamps.map<[string, string]>(stamp => [stamp.label, stamp.id]),
+    }]
+};

--- a/src/app/lib/modules/variables/api.ts
+++ b/src/app/lib/modules/variables/api.ts
@@ -43,6 +43,9 @@ export const VariablesAPI = {
         math_number: {
             NUM: '0',
         },
+        text: {
+            TEXT: '',
+        },
     },
 };
 

--- a/src/app/lib/parts/parts/mouse/api.ts
+++ b/src/app/lib/parts/parts/mouse/api.ts
@@ -4,7 +4,7 @@ import { svg } from '@kano/icons-rendering/index.js';
 import { addFlashField, setupFlash } from '../../../plugins/flash/flash.js';
 import { Block } from '@kano/kwc-blockly/blockly.js';
 import { Editor } from '../../../editor/editor.js';
-import { random, randomFrom } from '../../../modules/stamp/api.js';
+import { random, randomFrom } from '../../../modules/stamp/common.js';
 import { StickerPart } from '../sticker/sticker.js';
 import { _ } from '../../../i18n/index.js';
 

--- a/src/app/lib/parts/parts/sticker/api.ts
+++ b/src/app/lib/parts/parts/sticker/api.ts
@@ -2,7 +2,7 @@ import { sticker } from '@kano/icons/parts.js';
 import { IPartAPI } from '../../api.js';
 import { StickerPart } from './sticker.js';
 import { TransformAPI, onTransformInstall } from '../transform/api.js';
-import { random, randomFrom } from '../../../modules/stamp/api.js';
+import { random, randomFrom } from '../../../modules/stamp/common.js';
 import { Editor } from '../../../editor/editor.js';
 import { _ } from '../../../i18n/index.js';
 

--- a/src/app/lib/parts/parts/transform/api.ts
+++ b/src/app/lib/parts/parts/transform/api.ts
@@ -32,6 +32,7 @@ export const TransformAPI : IMetaDefinition[] = [
                 ['\u21BA', 'counterclockwise'],
                 [_('PART_TRANSFORM_TURN_TO', 'to'), 'to'],
             ],
+            default: 'clockwise',
         }, {
             type: 'parameter',
             name: 'rotation',

--- a/src/app/lib/source-editor/blockly/creator/helpers.ts
+++ b/src/app/lib/source-editor/blockly/creator/helpers.ts
@@ -1,6 +1,6 @@
 import { registerCreatorHelper } from '../../../creator/index.js';
 import { IGeneratedStep } from '../../../creator/creator.js';
-import { Field, FieldColour, FieldDropdown, FieldVariable, Workspace, Variables, FieldNumber } from '@kano/kwc-blockly/blockly.js';
+import { Field, FieldColour, FieldDropdown, FieldVariable, Workspace, Variables, FieldNumber, FieldTextInput } from '@kano/kwc-blockly/blockly.js';
 import '../challenge/ui/kc-color-preview.js';
 import '../challenge/ui/kc-string-preview.js';
 import { StampsField } from '../../../blockly/fields/stamps-field.js';
@@ -26,6 +26,14 @@ export function registerStepperFieldHelper<T extends Field>(fieldConstructor : a
         }
     });
 }
+
+registerCreatorFieldHelper(FieldTextInput, (field : FieldTextInput, prevValue : string, newValue : string, step : IGeneratedStep) => {
+    // For text input blocks with a default being an empty string, customise the message
+    if (prevValue === '') {
+        step.data.bannerCopy = `Type <kc-string-preview>${newValue}</kc-string-preview> here`;
+    }
+    return step;
+});
 
 registerCreatorFieldHelper(FieldNumber, (field : FieldNumber, prevValue : string, newValue : string, step : IGeneratedStep) => {
     step.data.bannerCopy = `Change <kc-string-preview>${prevValue}</kc-string-preview> to <kc-string-preview>${newValue}</kc-string-preview>`;

--- a/src/app/lib/source-editor/blockly/creator/xml.ts
+++ b/src/app/lib/source-editor/blockly/creator/xml.ts
@@ -130,6 +130,16 @@ export function findFirstTreeDiff(treeA : HTMLElement, treeB : HTMLElement) : ID
                 return { type: DiffResultType.INNER_TEXT, from: aText, to: bText, aNode: a, bNode: b }; 
             }
         }
+        // Value blocks behave differently as they can host both shadows and blocks
+        // THe value block might have 2 children. I which case, a block was added to replace the shadow block
+        if (a.tagName.toLowerCase() === 'value' && b.children.length === 2 && a.children.length === 1) {
+            // Find the normal block in the target tree
+            for (let i = 0; i < b.children.length; i += 1) {
+                if (b.children[i].tagName.toLowerCase() === 'block') {
+                    return { type: DiffResultType.NODE, from: a.children[0] as HTMLElement, to: b.children[i] as HTMLElement };
+                }
+            }
+        }
         let aChild;
         let bChild;
         const biggest = Math.max(a.children.length, b.children.length);


### PR DESCRIPTION
 - Added custom module with nested shadow in the creator demo for testing
 - Updated the XML tree diff of block to support the case of block and shadow block inside a value
 - Moved the sticker blocks into their own file so that the API file only exports the module
 - Added default values for part turn block and text block
 - Added helper to generate a custom banner text when the text block is used