### PR TITLE
shadow for customFields fix SX-1251

### DIFF
--- a/src/app/lib/source-editor/blockly/shadow.ts
+++ b/src/app/lib/source-editor/blockly/shadow.ts
@@ -29,7 +29,7 @@ export function resolveLegacyShadowTree(value : string|{ shadow : string }) {
 }
 
 export function resolveShadowTree(param : MetaParameter) {
-    if (param.def.blockly && param.def.blockly.field) {
+    if (param.def.blockly && (param.def.blockly.field || param.def.blockly.customField)) {
         return null;
     }
     switch(param.getReturnType()) {


### PR DESCRIPTION
If using a custom field, don't add a custom shadow to the field.