### PR TITLE
fix: canvas displays when editor and output load

### DIFF
--- a/src/app/lib/output/output.ts
+++ b/src/app/lib/output/output.ts
@@ -179,7 +179,6 @@ export class Output extends PluginReceiver {
             if (!this._queuedStart && running) {
                 this._queuedStart = true;
                 this._loading.then(() => {
-                    console.log(`then fired with state: ${running} 🏃‍♀️`)
                     this._running = running;
                     this._onDidRunningStateChange.fire(this._running);
                     this._queuedStart = false;


### PR DESCRIPTION
This should fix the blank canvas bug we're now seeing.