### PR TITLE
fix: Stamp performance degradation over time

### DIFF
--- a/src/app/lib/modules/draw/kano-canvas-api/modules/repeats.ts
+++ b/src/app/lib/modules/draw/kano-canvas-api/modules/repeats.ts
@@ -14,7 +14,7 @@ export class Repeats {
     * @param {Number} movement
     * @return void
     */
-    repeatDrawing(repeats : number, rotation : number, movementX : number, movementY : number, callback: Function) {   
+    repeatDrawing(repeats : number, rotation : number, movementX : number, movementY : number, callback: Function) {
         const previousX = this.session.pos.x;
         const previousY = this.session.pos.y;
         const moveX = movementX ? movementX : 0;
@@ -24,11 +24,13 @@ export class Repeats {
         }
         const previousTransform = this.session.transformation || [[1, 0, 0], [0, 1, 0], [0, 0, 1]];
 
+        this.session.ctx.beginPath();
+
         for( var i = 0; i < repeats; i++ ) {
             this.session.pos = { x: previousX + moveX * i, y: previousY + moveY * i };
-            callback(); 
+            callback();
             const all = calculateRotation({x: previousX, y: previousY}, rotation);
-            this.session.transformation = multiply(this.session.transformation, all); 
+            this.session.transformation = multiply(this.session.transformation, all);
             this.session.ctx.transform(all[0][0], all[1][0], all[0][1], all[1][1], all[0][2], all[1][2]);
         }
 
@@ -41,6 +43,8 @@ export class Repeats {
             previousTransform[0][2],
             previousTransform[1][2]
         );
+
+        this.session.ctx.closePath();
 
         this.session.pos = { x: previousX, y: previousY };
 

--- a/src/app/lib/modules/draw/kano-canvas-api/modules/stamp.ts
+++ b/src/app/lib/modules/draw/kano-canvas-api/modules/stamp.ts
@@ -36,6 +36,7 @@ export class Stamp {
 
             const aspectRatio = stamp.width / stamp.height;
 
+            session.ctx.beginPath();
             const all = calculateFullTransform({x: previousX, y: previousY}, rotation, percent, aspectRatio);
             session.ctx.transform(all[0][0], all[1][0], all[0][1], all[1][1], all[0][2], all[1][2]);
 
@@ -57,6 +58,7 @@ export class Stamp {
                 previousTransform[0][2],
                 previousTransform[1][2]
                 );
+            session.ctx.closePath();
 
         }
     };


### PR DESCRIPTION
Under the hood, canvas is stringing operations made into a path. It seems to be keeping track of the previous transforms made which leads to performance degradation over time. Beginning and closing a path for each transform resolves the problem.