### PR TITLE
fix: Sticker scaling issue

### DIFF
--- a/src/app/lib/modules/draw/kano-canvas-api/modules/stamp.ts
+++ b/src/app/lib/modules/draw/kano-canvas-api/modules/stamp.ts
@@ -34,10 +34,8 @@ export class Stamp {
                 return;
             }
 
-            const aspectRatio = stamp.width / stamp.height;
-
             session.ctx.beginPath();
-            const all = calculateFullTransform({x: previousX, y: previousY}, rotation, percent, aspectRatio);
+            const all = calculateFullTransform({x: previousX, y: previousY}, rotation, percent);
             session.ctx.transform(all[0][0], all[1][0], all[0][1], all[1][1], all[0][2], all[1][2]);
 
             const width = stamp.width / RESOURCE_CACHE_RESOLUTION_MULTIPLIER;

--- a/src/app/lib/modules/draw/kano-canvas-api/transformation.ts
+++ b/src/app/lib/modules/draw/kano-canvas-api/transformation.ts
@@ -4,7 +4,7 @@ export interface ITransformationArray {
 
 export const multiply = (a: any, b: any) => {
     const aNumRows = a.length;
-    const aNumCols = a[0].length; 
+    const aNumCols = a[0].length;
     const bNumCols = b[0].length;
     const m = new Array(aNumRows);
     for (let r = 0; r < aNumRows; r+=1) {
@@ -43,11 +43,11 @@ export function calculateRotation(origin: {x: number, y: number}, angle: number)
     return multiply(multiply(translate2, rotate), translate1);
 }
 
-export function calculateFullTransform(origin: {x: number, y: number}, angle: number, scale: number, aspectRatio: number) {
+export function calculateFullTransform(origin: {x: number, y: number}, angle: number, scale: number) {
 
     const r = angle * (Math.PI / 180);
-    const xx = Math.cos(r) * aspectRatio;
-    const xy = Math.sin(r) * aspectRatio;
+    const xx = Math.cos(r);
+    const xy = Math.sin(r);
 
     const translate1 = [
         [Math.cos(0),-Math.sin(0), -origin.x],


### PR DESCRIPTION
We were mistakenly scaling stickers by their aspect ratios which made assets behave inconsistently -- tall stickers like the ice crystals were small (width / height = low number) and wide stickers like the keytar and hotdog were huge (width / height = high number).

This PR will likely break challenges that use non-square stickers, but it shall bring the giant hotdog madness to an end.

Before:

<img width="832" alt="Screenshot 2019-09-20 at 13 21 36" src="https://user-images.githubusercontent.com/169328/65326540-9f4b9f00-dba9-11e9-8db2-e124b39b3fcc.png">

After:

<img width="856" alt="Screenshot 2019-09-20 at 13 19 33" src="https://user-images.githubusercontent.com/169328/65326548-a377bc80-dba9-11e9-87f8-9ad94d93bba8.png">
