### PR TITLE
feat: beacons for quote and stamp blocks

### DIFF
--- a/src/@types/@kano/kwc-blockly/blockly.d.ts
+++ b/src/@types/@kano/kwc-blockly/blockly.d.ts
@@ -75,6 +75,7 @@ declare module '@kano/kwc-blockly/blockly.js' {
         static getCachedWidth(text : SVGElement) : number;
         setText(v : string) : void;
         getScaledBBox_() : any;
+        getSvgRoot() : any;
         protected getDisplayText_() : string;
         protected updateWidth() : void;
         protected render_() : void;
@@ -118,6 +119,7 @@ declare module '@kano/kwc-blockly/blockly.js' {
         getFlyout_() : Flyout;
         addChangeListener(callback : (e : any) => void) : (e : any) => void;
         removeChangeListener(callback : (e : any) => void) : void;
+        fireChangeListener(e: Event) : void;
         getVariableById(id : string) : Variable|null;
         newBlock(type : string, id? : string) : T;
         cleanUp() : void;
@@ -205,6 +207,7 @@ declare module '@kano/kwc-blockly/blockly.js' {
     }
     class Events {
         UI : string;
+        Ui(a : any, b : any, c : any, d : any) : void;
         CREATE : string;
         MOVE : string;
         OPEN_FLYOUT : string;

--- a/src/app/elements/kc-quote-picker.ts
+++ b/src/app/elements/kc-quote-picker.ts
@@ -1,0 +1,34 @@
+import { html } from 'lit-element/lit-element.js';
+import { classMap } from 'lit-html/directives/class-map.js';
+
+import { KCIndexedPicker, IIndexedPickerItem } from './kc-indexed-picker.js';
+
+export class KCQuotePicker extends KCIndexedPicker {
+    onItemClick(item : IIndexedPickerItem) {
+        this.value = item.label;
+        this.id = item.id;
+        this.dispatchEvent(new CustomEvent('value-changed', { composed: true, bubbles: true, detail: item }));
+    }
+
+    renderItem(item : IIndexedPickerItem) {
+        return html`
+            <button class=${classMap({ item: true, selected: this.id === item.id })}
+                id=${item.id} @click=${() => this.onItemClick(item)}>
+                ${this.renderItemContent(item)}
+            </button>
+        `;
+    }
+
+    revealSelectedElement() {
+        if (!this.renderRoot) {
+            return;
+        }
+        const el = this.renderRoot.querySelector(`#${this.id}`);
+        if (!el) {
+            return;
+        }
+        el.scrollIntoView({ behavior: 'smooth' });
+    }
+}
+
+customElements.define('kc-quote-picker', KCQuotePicker);

--- a/src/app/lib/blockly/fields/field-picker.ts
+++ b/src/app/lib/blockly/fields/field-picker.ts
@@ -1,0 +1,99 @@
+import {
+    Blockly,
+    utils,
+    goog,
+    Field,
+} from '@kano/kwc-blockly/blockly.js';
+import '@kano/styles/color.js';
+import '@kano/styles/typography.js';
+import { subscribeDOM } from '@kano/common/index.js';
+import '../../../elements/kc-quote-picker.js';
+import { IItemData } from './stamps-field.js';
+import { KCQuotePicker } from '../../../elements/kc-quote-picker.js';
+
+export class FieldPicker extends Field {
+    private domNode: KCQuotePicker | null = null;
+    private items: IItemData[];
+    constructor(value: string, items: IItemData[], optValidator?: () => void) {
+        super(value, optValidator);
+        this.items = items;
+    }
+
+    showEditor_() {
+        if (!this.domNode) {
+            this.domNode = document.createElement('kc-quote-picker') as KCQuotePicker;
+            this.domNode.style.border = '2px solid var(--kc-border-color)';
+            this.domNode.style.borderRadius = '6px';
+            this.domNode.style.overflow = 'hidden';
+            this.domNode.style.boxShadow = '0px 4px 4px 0px rgba(0, 0, 0, 0.15)';
+            this.domNode.items = this.items.map((set) => {
+                return {
+                    id: set.id,
+                    label: set.label,
+                    items: set.resources.map(item => ({
+                        id: item.id,
+                        label: item.label,
+                    })),
+                };
+            });
+            subscribeDOM(this.domNode, 'value-changed', (e : CustomEvent) => {
+                this.setValue(e.detail.label);
+            });
+        }
+        Blockly.WidgetDiv.show(
+            this,
+            this.sourceBlock_.RTL,
+            FieldPicker.widgetDispose_,
+        );
+        const div = Blockly.WidgetDiv.DIV;
+        div.appendChild(this.domNode);
+        this.domNode.value = this.getValue();
+        const item = this.getItemForValue(this.domNode.value);
+        if (item && item.id) {
+            this.domNode.id = item.id;
+        }
+        this.position();
+        if ('animate' in HTMLElement.prototype) {
+            div.animate({
+                opacity: [0, 1],
+            }, {
+                duration: 100,
+                easing: 'ease-out',
+            });
+        }
+        setTimeout(() => {
+            if (!this.domNode) {
+                return;
+            }
+            this.domNode.revealSelectedElement();
+        });
+    }
+
+    position() {
+        const viewportBBox = utils.getViewportBBox();
+        const anchorBBox = this.getScaledBBox_();
+        const elementSize = goog.style.getSize(this.domNode);
+        Blockly.WidgetDiv.positionWithAnchor(
+            viewportBBox,
+            anchorBBox,
+            elementSize,
+            this.sourceBlock_.RTL,
+        );
+    }
+
+    getItemForValue(value : string) {
+        for (let i = 0; i < this.items.length; i += 1) {
+            const found = this.items[i].resources.find(s => s.label === value);
+            if (found) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    getOptions() {
+        return this.items;
+    }
+
+    static widgetDispose_() { }
+}

--- a/src/app/lib/blockly/fields/icon.ts
+++ b/src/app/lib/blockly/fields/icon.ts
@@ -94,6 +94,11 @@ export abstract class FieldIcon extends Field {
             Blockly.WidgetDiv.hide();
         } else if (!this.sourceBlock_.isInFlyout) {
             this.showEditor_();
+            // Seeing as preventdefault is being called, and we want some of 
+            // the default functionality, triggering a UI Event click to tell the 
+            // workspace that the widget has been opened. 
+            const event = new (Blockly.Events.Ui as any)(this.sourceBlock_, 'click', undefined, undefined);
+            Blockly.Events.fire(event);
             e.preventDefault();
             e.stopPropagation();
         }

--- a/src/app/lib/blockly/fields/stamps-field.ts
+++ b/src/app/lib/blockly/fields/stamps-field.ts
@@ -6,10 +6,16 @@ import '../../../elements/kc-indexed-picker.js';
 import { KCIndexedPicker } from '../../../elements/kc-indexed-picker.js';
 import { subscribeDOM } from '@kano/common/index.js';
 
-interface IItemData {
+export interface IItemDataResource {
     id : string;
     label : string;
-    resources : { id : string, label: string, src : string }[];
+    src : string;
+}
+
+export interface IItemData {
+    id : string;
+    label : string;
+    resources: IItemDataResource[];
 }
 
 export class StampsField extends FieldIcon {
@@ -115,6 +121,9 @@ export class StampsField extends FieldIcon {
             return item.label;
         }
         return '';
+    }
+    getOptions() {
+        return this.items;
     }
     static widgetDispose_() {}
 }

--- a/src/app/lib/source-editor/blockly/challenge/helpers/indexed-picker.ts
+++ b/src/app/lib/source-editor/blockly/challenge/helpers/indexed-picker.ts
@@ -1,0 +1,162 @@
+import { WidgetDiv } from '@kano/kwc-blockly/blockly.js';
+import { FieldPicker } from '../../../../blockly/fields/field-picker.js'
+import { StampsField } from '../../../../blockly/fields/stamps-field.js'
+import { KanoCodeChallenge } from '../kano-code.js';
+import { BlocklyValueStepHelper } from './value.js';
+import { IStepData } from '../../../../creator/creator.js';
+import { BeaconWidget } from '../../../../challenge/widget/beacon.js';
+import { IDisposable } from '@kano/common/index.js';
+import { IItemData, IItemDataResource } from '../../../../blockly/fields/stamps-field.js';
+import { throttle } from '../../../../decorators.js';
+import { Resource } from '../../../../output/resources.js';
+
+class IndexedPickerBeaconWidget extends BeaconWidget {
+    getPosition() { return 'picker-target:0,50'; }
+    getDomNode() {
+        const node = super.getDomNode();
+        node.style.zIndex = '200000';
+        return node;
+    }
+}
+
+export class IndexedPickerFieldStepHelper extends BlocklyValueStepHelper {
+    beacon: IndexedPickerBeaconWidget | null = null;
+    listener?: (e: any) => void;
+    tagHandler?: IDisposable;
+
+    testCase(challenge: KanoCodeChallenge, step: IStepData) {
+        const field = this.getField(challenge, step);
+        return field && field.constructor === StampsField;
+    }
+
+    test(challenge: KanoCodeChallenge, step: IStepData) {
+        if (!super.test(challenge, step)) {
+            return false;
+        }
+        return this.testCase(challenge, step);
+    }
+    setupBeacon(challenge: KanoCodeChallenge) {
+        if (!this.beacon) {
+            this.beacon = new IndexedPickerBeaconWidget();
+            challenge.editor.addContentWidget(this.beacon);
+            const engineBeacon = challenge.widgets.get('beacon');
+            if (engineBeacon) {
+                const node = engineBeacon.getDomNode();
+                node.style.opacity = '0';
+            }
+        }
+    }
+    removeBeacon(challenge: KanoCodeChallenge) {
+        if (this.beacon) {
+            challenge.editor.removeContentWidget(this.beacon);
+            this.beacon = null;
+            const engineBeacon = challenge.widgets.get('beacon');
+            if (engineBeacon) {
+                const node = engineBeacon.getDomNode();
+                node.style.opacity = '';
+            }
+        }
+    }
+    enter(challenge: KanoCodeChallenge, step: IStepData) {
+        const field = this.getField(challenge, step) as FieldPicker;
+        const options: IItemData[] = field.getOptions();
+
+        let targetItems : IItemDataResource[] = []
+        Object.values(options).forEach((item) => {
+            item.resources.forEach(el => targetItems.push(el))
+        });
+
+        if (!challenge.workspace) {
+            return;
+        }
+        const getItem = this.getItem.bind(this);
+        this.tagHandler = challenge.editor.queryEngine.registerTagHandler('picker-target', () => {
+            return {
+                getHTMLElement() {
+                    const item = getItem(step.validation.blockly.value.value, targetItems);
+                    if (!item) {
+                        return field.getSvgRoot();
+                    }
+                    item.scrollIntoView({ behavior: 'smooth' });
+                    return item;
+                },
+                getId() { return 'picker-target'; }
+            };
+        });
+        // Listen to changes in the editor. For each change, add or remove the beacon
+        this.listener = (e: any) => {
+            const scrollingEl : HTMLElement = this.getScrollingElement() as HTMLElement;
+            if (!scrollingEl) {
+                return;
+            }
+            scrollingEl.addEventListener('scroll', (event: Event) => this.onScroll(event, challenge));
+            const item = this.getItem(step.validation.blockly.value.value, targetItems);
+            if (item) {
+                this.setupBeacon(challenge);
+            } else {
+                this.removeBeacon(challenge);
+            }
+        };
+        challenge.workspace.addChangeListener(this.listener);
+    }
+    leave(challenge: KanoCodeChallenge, step: IStepData) {
+        if (this.listener && challenge.workspace) {
+            challenge.workspace.removeChangeListener(this.listener);
+        }
+        if (this.beacon) {
+            challenge.editor.removeContentWidget(this.beacon);
+            this.beacon = null;
+        }
+        if (this.tagHandler) {
+            this.tagHandler.dispose();
+        }
+    }
+
+    getItem(id: string, targetItems: IItemDataResource[]) {
+        const shadow = this.getShadowElement();
+        if (!shadow) {
+            return;
+        }
+        const items = shadow.querySelectorAll('.item');
+        const item = Array.from(items).find(item => item.id === id) as HTMLElement;
+        return item;
+    }
+
+    getIdFromValue(value: string, targetItems: IItemDataResource[]) {
+        const item = targetItems.find((el: IItemDataResource) => value === el.label);
+        let id = '';
+        if (item && item.id) {
+            id = item.id;
+        }
+        return id;
+    }
+
+    getShadowElement() {
+        if (!WidgetDiv || !WidgetDiv.DIV || !WidgetDiv.DIV.firstChild) {
+            return;
+        }
+        const picker = WidgetDiv.DIV.firstChild as HTMLElement;
+        const shadow = picker.shadowRoot;
+        if (!shadow) {
+            return;
+        }
+        return shadow;
+    }
+
+    getScrollingElement() {
+        const shadow = this.getShadowElement();
+        if (!shadow) {
+            return;
+        }
+        const scrollingEl = shadow.querySelector('.items');
+        return scrollingEl;
+    }
+
+    @throttle(500)
+    protected onScroll(e: Event, challenge: KanoCodeChallenge) {
+        if (challenge && challenge.workspace) {
+            challenge.workspace.fireChangeListener(e);
+        }
+    }
+
+}

--- a/src/app/lib/source-editor/blockly/challenge/helpers/quote-picker.ts
+++ b/src/app/lib/source-editor/blockly/challenge/helpers/quote-picker.ts
@@ -1,0 +1,24 @@
+import { IndexedPickerFieldStepHelper } from './indexed-picker.js';
+import { IItemDataResource } from '../../../../blockly/fields/stamps-field.js';
+import { FieldPicker } from '../../../../blockly/fields/field-picker.js';
+import KanoCodeChallenge from '../kano-code.js';
+import { IStepData } from '../../../../creator/creator.js';
+
+export class QuotePickerFieldStepHelper extends IndexedPickerFieldStepHelper {
+
+    testCase(challenge: KanoCodeChallenge, step: IStepData) {
+        const field = this.getField(challenge, step);
+        return field && field.constructor === FieldPicker;
+    }
+
+    getItem(value: string, targetItems?: IItemDataResource[], ) {
+        const shadow = this.getShadowElement();
+        if (!shadow || !targetItems) {
+            return;
+        }
+        const id = this.getIdFromValue(value, targetItems);
+        const items = shadow.querySelectorAll('.item');
+        const item = Array.from(items).find(item => item.id === id) as HTMLElement;
+        return item;
+    }
+}

--- a/src/app/lib/source-editor/blockly/challenge/kano-code.ts
+++ b/src/app/lib/source-editor/blockly/challenge/kano-code.ts
@@ -11,6 +11,8 @@ import '../../../challenge/components/kc-toolbox-entry-preview.js';
 import '../../../challenge/components/kc-part-api-preview.js';
 import { dataURI } from '@kano/icons-rendering/index.js';
 import { DropdownFieldStepHelper } from './helpers/dropdown.js';
+import { IndexedPickerFieldStepHelper } from './helpers/indexed-picker.js';
+import { QuotePickerFieldStepHelper } from './helpers/quote-picker.js';
 import { BannerHelper } from './helpers/banner.js';
 import { button } from '@kano/styles/button.js';
 
@@ -61,6 +63,8 @@ export class KanoCodeChallenge extends BlocklyChallenge {
         this.editor.domNode.shadowRoot!.appendChild(button.content.cloneNode(true));
 
         this.helpers.push(new DropdownFieldStepHelper());
+        this.helpers.push(new IndexedPickerFieldStepHelper());
+        this.helpers.push(new QuotePickerFieldStepHelper());
         this.helpers.push(new BannerHelper());
     }
     /**

--- a/src/app/lib/source-editor/blockly/challenge/ui/kc-string-preview.ts
+++ b/src/app/lib/source-editor/blockly/challenge/ui/kc-string-preview.ts
@@ -14,7 +14,7 @@ export class KcStringPreview extends LitElement {
                 vertical-align: middle;
                 border-radius: 3px;
                 border: 1px solid var(--color-grey);
-                height: 18px;
+                min-height: 18px;
                 min-width: 18px;
                 line-height: 18px;
                 text-align: center;


### PR DESCRIPTION
- Beacons for stamp selector
- Scroll user to the correct stamp, almost forcefully (can be iterated on)
- beacons for quote selector too, same deal
- mini fix for string preview, needs real design solution:
![image](https://user-images.githubusercontent.com/11870096/66771403-16770900-eeb2-11e9-83d0-38ae819d1436.png)

