### PR TITLE
fix: removing a part also removes it from the toolbox - KC-6

### DIFF
--- a/src/app/lib/editor/toolbox.ts
+++ b/src/app/lib/editor/toolbox.ts
@@ -68,8 +68,8 @@ export class Toolbox extends Plugin {
         return disposableEntry;
     }
     removeEntry(entry : IAPIDefinition) {
-        const index = this.entries.indexOf(entry);
-        this.entries.splice(index, 1);
+        const index = this._entries.indexOf(entry);
+        this._entries.splice(index, 1);
         this.update();
     }
     updateEntry(oldEntry : IAPIDefinition, entry : IAPIDefinition) {


### PR DESCRIPTION
Not sure if I should be removing them from `this._entries` instead of `this.entries` OR remove them from both?