### PR TITLE
fix: ios audio context

### DIFF
--- a/src/app/lib/output/default.ts
+++ b/src/app/lib/output/default.ts
@@ -5,9 +5,7 @@ import { Microphone } from './microphone.js';
 import { EventEmitter } from '@kano/common/index.js';
 import { DefaultResources } from './default-resources.js';
 
-function degreesToRadians(deg: number) {
-    return deg * (Math.PI / 180);
-}
+window.AudioContext = window.AudioContext || (window as any).webkitAudioContext;
 
 export class DefaultOutputViewProvider extends OutputViewProvider {
     private canvas : HTMLCanvasElement;


### PR DESCRIPTION
- webkitAudioContext used if AudioContext not present on window
- remove unused function