### PR TITLE
Fix duplication of parts when renaming them

### DIFF
--- a/src/app/elements/kc-workspace-frame/kc-parts-controls.ts
+++ b/src/app/elements/kc-workspace-frame/kc-parts-controls.ts
@@ -205,7 +205,7 @@ export class KCPartsControls extends LitElement {
         return this.renderRoot.querySelector(`#part-${id}`) as HTMLElement;
     }
     addEntry(model : IStackEntry) : IPartsControlsEntry {
-        const item = model;
+        let item = model;
         const entry : IPartsControlsEntry = {
             _onDidChangeName: new EventEmitter<string>(),
             get onDidChangeName() { return this._onDidChangeName.event },
@@ -214,6 +214,8 @@ export class KCPartsControls extends LitElement {
                 const index = this.parts.indexOf(item);
                 this.parts.splice(index, 1, model);
                 this.parts = [...this.parts];
+                item = model;
+                item.entry = entry;
             },
             dispose: () => {
                 item.inlineDisplay.onDispose();

--- a/src/app/lib/editor/toolbox.ts
+++ b/src/app/lib/editor/toolbox.ts
@@ -78,8 +78,8 @@ export class Toolbox extends Plugin {
         this.update();
     }
     updateEntry(oldEntry : IAPIDefinition, entry : IAPIDefinition) {
-        const index = this.entries.indexOf(oldEntry);
-        this.entries.splice(index, 1, entry);
+        const index = this._entries.indexOf(oldEntry);
+        this._entries.splice(index, 1, entry);
         this.update();
     }
     setWhitelist(whitelist : IToolboxWhitelist|null) {


### PR DESCRIPTION
This PR is a proposed fix for #1804 

When updating a toolbox entry it appears that the passed `IAPIDefinition` was being incorrectly  spliced out of `this.entries` (which is an array of `IAPIJointDefinition`). Instead, the splice should be happening on `this._entries`. Switching arrays fixes the duplication issue but reveals another problem...

The `IPartsControlsEntry.update()` method returned by `KCPartsControls.addEntry` overwrites the original model when it's called. As a result the new model has no reference to its `IPartsControlsEntry`, which causes the browser to throw an error when attempting to rename for a second time.