### PR TITLE
Ensure part names begin with valid characters

### DIFF
--- a/src/app/elements/kc-workspace-frame/kc-parts-controls.ts
+++ b/src/app/elements/kc-workspace-frame/kc-parts-controls.ts
@@ -237,6 +237,9 @@ export class KCPartsControls extends LitElement {
         if (existing) {
             return 'A part with that name already exist';
         }
+        if (!/^[a-z]/i.test(newName)) {
+            return 'A part name must begin with a letter';
+        }
         return true;
     }
 }


### PR DESCRIPTION
Proposed fix for #1806 

This PR modifies the `_validatePartName()` method of the `<kc-parts-controls>` component to check that the first character of a part name is a letter (a-z or A-Z). This covers off the case of names beginning with non-valid characters and accidentally setting names to empty string values.

With an invalid first character:
![Screen Shot 2020-01-12 at 23 27 24](https://user-images.githubusercontent.com/588665/72227400-0dbacf80-3594-11ea-8615-a38dab902460.png)

With an empty string:
![Screen Shot 2020-01-12 at 23 27 32](https://user-images.githubusercontent.com/588665/72227402-101d2980-3594-11ea-856a-77a3c1470037.png)

This could be extended to provide an alternative message for empty strings.