### PR TITLE
fix: curly brace in math.sign code generator

### DIFF
--- a/src/app/lib/modules/math/api.ts
+++ b/src/app/lib/modules/math/api.ts
@@ -185,7 +185,7 @@ export const MathAPI = {
 
         Blockly.JavaScript.math_sign = (block : Block) => {
             let arg = Blockly.JavaScript.valueToCode(block, 'ARG', Blockly.JavaScript.ORDER_NONE),
-                code = `math.sign(${arg}})`;
+                code = `math.sign(${arg})`;
             return [code, Blockly.JavaScript.ORDER_FUNCTION_CALL];
         };
 


### PR DESCRIPTION
Just noticed while exploring that the math sign block generates an unnecessary curly brace which leads to broken code. 
