### PR TITLE
Only round translation values at render

### DIFF
--- a/src/app/lib/parts/parts/dom/dom.ts
+++ b/src/app/lib/parts/parts/dom/dom.ts
@@ -65,8 +65,8 @@ export abstract class DOMPart<T extends HTMLElement = HTMLElement> extends Part 
             // this.size / 2 is for transforming to center of image instead of corner
             // the scale is multiplied by 2 to make parts more visible
             const transform = {
-                x: (this.transform.x * this._canvasScale) - (this.size.width / 2),
-                y: (this.transform.y * this._canvasScale) - (this.size.height / 2),
+                x: Math.round((this.transform.x * this._canvasScale) - (this.size.width / 2)),
+                y: Math.round((this.transform.y * this._canvasScale) - (this.size.height / 2)),
                 scale: this.transform.scale * this._canvasScale * 2,
             };
             this._el.style.transform = `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale}, ${transform.scale}) rotate(${this.transform.rotation}deg)`;
@@ -145,8 +145,8 @@ export abstract class DOMPart<T extends HTMLElement = HTMLElement> extends Part 
     }
     moveAlong(distance : number) {
         const direction = (this.transform.rotation || 0) * Math.PI / 180;
-        const alongY = Math.round(distance * Math.sin(direction));
-        const alongX = Math.round(distance * Math.cos(direction));
+        const alongY = distance * Math.sin(direction);
+        const alongX = distance * Math.cos(direction);
         this.move(alongX, alongY);
     }
     move(x : number, y : number) {


### PR DESCRIPTION
This PR fixes a rounding bug with transform API when moving elements with `moveAlong` function (called by the "move distance" block).

The `moveAlong` function is rounding transform values each time it's called. This introduces calculation errors when the method is called as part of a chain of transform functions. This change moves the `Math.round` call to the `render` method so rounding only occurs when the transform is used to draw.