### PR TITLE
Fix elseIf UI showing `NaN` instead of a value.

### DIFF
--- a/src/app/lib/modules/logic/api.ts
+++ b/src/app/lib/modules/logic/api.ts
@@ -54,7 +54,7 @@ export const LogicAPI = {
         Blockly.JavaScript.controls_if_else_custom = Blockly.JavaScript.controls_if;
         Blockly.Blocks.controls_if_else_custom.init = function () {
             Blockly.Blocks.controls_if.init.call(this);
-            this.setFieldValue(JSON.stringify({ elseIfs: this.elseifCount_, else: true, }), 'CONFIG');
+            this.setFieldValue(JSON.stringify({ elseIfs: this.elseifCount_ || 0 , else: true, }), 'CONFIG');
         };
 
         // Assign custom color to blockly core blocks


### PR DESCRIPTION
# Description

This PR fixes an issue with the "else" count UI in the`if/else` variant of the if logic blocks. Adding a block and clicking`...` shows the UI for managing the block. In the screen grab below you can see that the `elseif` value is blank (it should be `0`):

![Screen Shot 2020-01-29 at 22 36 30](https://user-images.githubusercontent.com/588665/73403676-dcf2ce00-42e7-11ea-9e68-cef60983f387.png) :x: 

Clicking `+` or `-` triggers an update, which results in `NaN`:
![Screen Shot 2020-01-29 at 22 36 38](https://user-images.githubusercontent.com/588665/73403679-dfedbe80-42e7-11ea-8684-950a540e895a.png) :x: 

This update ensures that `controls_if_else_custom.elseIfs` is initialized to `0`, which fixes the problem:

![Screen Shot 2020-01-29 at 22 43 52](https://user-images.githubusercontent.com/588665/73404123-dadd3f00-42e8-11ea-87dd-105cdf7697ec.png) ✅  

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Source

Here's the source for creating app that shows the issue:

```js
{
  "source": "<xml xmlns=\"http://www.w3.org/1999/xhtml\"><block type=\"controls_if_else_custom\" id=\"|eI3i*DR~|q`}/2G_OUo\" x=\"454\" y=\"187\"><field name=\"CONFIG\">{\"else\":true,\"elseIfs\":null}</field></block></xml>",
  "code": "if (false) {\n} else {\n}\n",
  "parts": [],
  "profile": "default"
}
```