### PR TITLE
Editing the default challenge copy

### DIFF
--- a/src/app/lib/source-editor/blockly/creator/copy.ts
+++ b/src/app/lib/source-editor/blockly/creator/copy.ts
@@ -7,21 +7,21 @@ import { registerCopyGenerator } from '../../../creator/copy.js';
 
 registerCopyGenerator('blockly', 'default', {
     openFlyout(category : string) {
-        return `Open the \${${category}} tray`;
+        return `Open the \${${category}} tray.`;
     },
     grabBlock() {
-        return 'Drag this block with your mouse or finger into the code space';
+        return 'Drag this block into the code space.';
     },
     connect() {
-        return 'Connect to this block';
+        return 'Connect to this block.';
     },
     drop() {
-        return 'Drop the block anywhere in your code space';
+        return 'Drop this block anywhere in your code space.';
     },
     value(defaultValue : string, currentValue : string) {
-        return `Change <kc-string-preview>${defaultValue}</kc-string-preview> to <kc-string-preview>${currentValue}</kc-string-preview>`;
+        return `Change <kc-string-preview>${defaultValue}</kc-string-preview> to <kc-string-preview>${currentValue}</kc-string-preview>.`;
     },
     openParts(part : string) {
-        return `Add a \${${part}} part, use the Add Parts button`;
+        return `Add a \${${part}} part, using the Add Parts button.`;
     },
 });


### PR DESCRIPTION
I've modified the default challenge copy so it suits the current style (i.e. it has full stops now), as well as some other changes (i.e. removing the 'with your mouse or finger' copy, which isn't as useful after the first few challenges). 

