### PR TITLE
added blockly_media to editor option interface

### DIFF
--- a/src/app/lib/editor/editor.ts
+++ b/src/app/lib/editor/editor.ts
@@ -54,6 +54,7 @@ export interface IEditorOptions {
     sourceType? : string;
     mediaPath? : string;
     blockly? : any;
+    BLOCKLY_MEDIA?: string;
 }
 
 export interface ICreationBundle {}


### PR DESCRIPTION
BLOCKLY_MEDIA was recently added as as an editor config option in kano code mini to point blockly to the correct sound asset path

This PR adds BLOCKLY_MEDIA as a property of IEditorOptions