### PR TITLE
fix: Whitespace breaks markdown content

### DIFF
--- a/src/app/elements/kano-editor-banner/kano-editor-banner.ts
+++ b/src/app/elements/kano-editor-banner/kano-editor-banner.ts
@@ -62,7 +62,7 @@ export class KCEditorBanner extends LitElement {
             .info {
                 padding: 0 12px;
             }
-        
+
             slot[name="hint-button"]::slotted(button) {
                 border-radius: 5px;
                 border: none;
@@ -77,7 +77,7 @@ export class KCEditorBanner extends LitElement {
             slot[name="hint-button"]::slotted(button:hover) {
                 color: #D95000;
             }
-            
+
             .content {
                 flex-direction: column;
                 font-family: var(--font-body);
@@ -93,7 +93,7 @@ export class KCEditorBanner extends LitElement {
                 float: right;
                 margin-right: 8px;
             }
-            
+
             .title {
                 color: var(--color-grey);
                 font-weight: bold;
@@ -176,6 +176,7 @@ export class KCEditorBanner extends LitElement {
     }
 
     render() {
+        const textContent = this.text ? marked(this.text.trim()) : '';
         return html`
         <div class="block block-1">
             <slot name="avatar"></slot>
@@ -184,9 +185,7 @@ export class KCEditorBanner extends LitElement {
         </div>
         </div>
         <div class="content">
-            <div class="markdown-html" id="markdown-html">
-                ${marked(this.text)}
-            </div>
+            <div class="markdown-html" id="markdown-html">${textContent}</div>
             <div class="info">
                 <slot name="info"></slot>
             </div>


### PR DESCRIPTION
When a markdown banner content starts with a <tag> that has whitespace
prepended to it, marked interprets that as a code block and formats that
instead of rendering HTML.

This should fix that.

<img width="863" alt="Screenshot 2020-06-03 at 12 46 13" src="https://user-images.githubusercontent.com/169328/83633256-8dbff100-a598-11ea-8096-f4b19089c539.png">
