### PR TITLE
fix: Normalise sticker sizes into 150x150 bounding box

### DIFF
--- a/src/app/lib/output/resources.ts
+++ b/src/app/lib/output/resources.ts
@@ -149,6 +149,18 @@ export class Resource<T> implements IResourceInformation {
 
     rasteriseImage(img : HTMLImageElement) {
         const canvas = document.createElement('canvas');
+
+        /* Normalise stickers to fit a 150x150 bounding box */
+        if ((img.width !== 150 && img.height !== 150) || (img.width > 150 || img.height > 150)) {
+            if (img.width >= img.height) {
+                img.height = Math.round((150 / img.width) * img.height);
+                img.width = 150;
+            } else {
+                img.width = Math.round((150 / img.height) * img.width);
+                img.height = 150;
+            }
+        }
+
         canvas.width = img.width * RESOURCE_CACHE_RESOLUTION_MULTIPLIER;
         canvas.height = img.height * RESOURCE_CACHE_RESOLUTION_MULTIPLIER;
         const ctx = canvas.getContext('2d');


### PR DESCRIPTION
This fixes the issue of size differences between different browsers.

However, it also changes the sizes of some stickers, and that will break some existing shares (anything with the keytar in it for example).