### PR TITLE
Relocate widgetDiv for challenges

### DIFF
--- a/src/app/lib/source-editor/blockly.ts
+++ b/src/app/lib/source-editor/blockly.ts
@@ -6,7 +6,7 @@
 import { EventEmitter, subscribeDOM, IDisposable } from '@kano/common/index.js';
 import { SourceEditor } from './source-editor.js';
 import '../../elements/kc-blockly-editor/kc-blockly-editor.js';
-import { Workspace, Block, Input, utils, Connection, Field } from '@kano/kwc-blockly/blockly.js';
+import { Workspace, Block, Blockly, Input, utils, Connection, Field } from '@kano/kwc-blockly/blockly.js';
 import './blockly/patches/index.js';
 import Editor from '../editor/editor.js';
 import { QueryEngine, ISelector, IQueryResult } from '../editor/selector/selector.js';
@@ -36,6 +36,12 @@ export class BlocklySourceEditor implements SourceEditor {
             this._onDidSourceChange.fire(e.detail);
         });
         this.editor.onDidInject(() => {
+            // If the widgetDiv has been removed from the DOM but exists in blockly add it back to the DOM
+            const hasWidgetDiv = document.body.querySelectorAll('.blocklyWidgetDiv').length;
+            if(!hasWidgetDiv && Blockly.WidgetDiv.DIV) {
+                document.body.appendChild(Blockly.WidgetDiv.DIV);
+            }
+
             const workspace = (this.domNode as any).getBlocklyWorkspace() as Workspace;
             workspace.addChangeListener((e) => {
                 // Be greedy for now. TODO: tweak this to ignore non relevent events

--- a/src/app/lib/source-editor/blockly/challenge/blockly.ts
+++ b/src/app/lib/source-editor/blockly/challenge/blockly.ts
@@ -57,6 +57,12 @@ class BlocklyChallenge extends Engine {
         super._updateStep();
         // Fixes an issue with challenges on iOS 12. Does not fix Dad fingers issue
         Promise.resolve().then(() => {
+            // Move the blocklyWidgetDiv to the same level as the editor div for beacons to layer correctly
+            const editorParent = this.editor.domNode.parentNode;
+            if(editorParent) {
+                editorParent.insertBefore(Blockly.WidgetDiv.DIV, this.editor.domNode);
+            }
+
             Blockly.WidgetDiv.hide();
         });
     }
@@ -430,6 +436,10 @@ class BlocklyChallenge extends Engine {
             return false;
         }
         return this._checkEvent(validation, detail);
+    }
+
+    dispose() {
+        super.dispose();
     }
 }
 

--- a/src/app/lib/source-editor/blockly/challenge/blockly.ts
+++ b/src/app/lib/source-editor/blockly/challenge/blockly.ts
@@ -437,10 +437,6 @@ class BlocklyChallenge extends Engine {
         }
         return this._checkEvent(validation, detail);
     }
-
-    dispose() {
-        super.dispose();
-    }
 }
 
 export default BlocklyChallenge;


### PR DESCRIPTION
For challenge beacons to layer properly with Blockly parts, the widgetDiv gets moved alongside the editor node in the dom so z-index is handled correctly.

Added fallback as well to re-insert the widgetDiv if it ever gets lost on a reload when the editor is re-initialised. 