### PR TITLE
reset parts on code change

### DIFF
--- a/src/app/lib/editor/editor.ts
+++ b/src/app/lib/editor/editor.ts
@@ -385,6 +385,8 @@ export class Editor extends EditorOrPlayer {
      * @param content the generated code
      */
     setCode(content? : string) {
+        // reset parts on code change
+        this.parts.getAddedParts().forEach(part => part.part.reset());
         this.output.setCode(content);
         this.domNode.code = content;
         this.output.restart();


### PR DESCRIPTION
BUGFIX:

parts can break and become unresponsive if they are assigned a variable which is unassigned.

this fix resets all parts before on a code change.